### PR TITLE
Fix settings import

### DIFF
--- a/dcstreethockey/urls.py
+++ b/dcstreethockey/urls.py
@@ -17,7 +17,7 @@ from django.conf.urls import include, url
 from django.contrib import admin
 import core.views as core_view
 from django.conf.urls.static import static
-import settings
+from django.conf import settings
 import leagues
 
 urlpatterns = [


### PR DESCRIPTION
i'm not sure how this was working before, but the existing import doesn't work on my machine.

I *think* it might be that python2 imports from the local directory, and python3 doesn't unless you explicitly say the same directory (i.e. `import .settings`).  Regardless, the proper way to load Django settings is via `django.conf`