### PR TITLE
Update roster to show all players even if they have never gotten a stat.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,17 @@ ENV PYTHONUNBUFFERED 1
 
 ENV RUN_DOCKER "True"
 
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main" >  /etc/apt/sources.list.d/pgdg.list
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN apt-get update
-RUN apt-get install -y python-psycopg2 postgresql-client ipython
+RUN apt-get install -y postgresql-client-10 ipython
 RUN mkdir -p /app
 RUN wget -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py
 RUN python /tmp/get-pip.py
 RUN wget https://cli-assets.heroku.com/heroku-cli/channels/stable/heroku-cli-linux-x64.tar.gz -O heroku.tar.gz && \
     tar -xvzf heroku.tar.gz && \
     mkdir -p /usr/local/lib /usr/local/bin && \
-    mv heroku-cli-v6.14.43-73d5876-linux-x64 /usr/local/lib/heroku && \
+    mv heroku-cli-v6.* /usr/local/lib/heroku && \
     ln -s /usr/local/lib/heroku/bin/heroku /usr/local/bin/heroku
 WORKDIR /app
 ADD requirements.txt /app/

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@
 1. heroku config:set DJANGO_SETTINGS_MODULE=dcstreethockey.settings.production
 
 ## Create backup of heroku database and restore in local postgres instance
-1. heroku pg:backups:capture
-1. heroku pg:backups:download
+1. heroku login
+1. heroku pg:backups:capture --app dcstreethockey
+1. heroku pg:backups:download --app dcstreethockey
 1. Restore downloaded db to local postgres instance: 
    - pg_restore --verbose --clean --no-acl --no-owner -h localhost -U user -d dcstreethockey latest.dump.[backup number]
 1. For docker   

--- a/core/views.py
+++ b/core/views.py
@@ -106,8 +106,7 @@ class PlayerStatDetailView(ListView):
 
 def get_player_stats(players, season):
     if season == 0:
-        return players.filter(
-                    stat__matchup__is_postseason=False).values(
+        return players.values(
                     'last_name',
                     'first_name',
                     'roster__team__team_name',

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ gunicorn==19.3.0
 olefile==0.44
 packaging==16.8
 Pillow==4.0.0
-psycopg2==2.6
 pyparsing==2.1.10
 pytz==2016.6.1
 six==1.10.0
@@ -52,7 +51,6 @@ pexpect==4.2.1
 pickleshare==0.7.4
 Pillow==4.0.0
 prompt-toolkit==1.0.15
-psycopg2==2.6
 ptyprocess==0.5.2
 pyflakes==1.5.0
 Pygments==2.2.0
@@ -99,7 +97,7 @@ pexpect==4.2.1
 pickleshare==0.7.4
 Pillow==4.0.0
 prompt-toolkit==1.0.15
-psycopg2==2.6
+psycopg2==2.7
 ptyprocess==0.5.2
 pyflakes==1.5.0
 Pygments==2.2.0


### PR DESCRIPTION
Change took 5 minutes. Getting the latest data into my setup took an hour and a half because of a postgres update to 10.3. The default jessie distro that the python 2.7 image uses doesn't have postgresql-client-10 so pg_restore was failing with `pg_restore: [archiver] unsupported version (1.13) in file header`

Edited dockerfile to use the PostgreSQL Apt Repository and install postgresql-client-10