### PR TITLE
Add margin to top of pages on mobile

### DIFF
--- a/static/assets/css/main.css
+++ b/static/assets/css/main.css
@@ -1737,6 +1737,7 @@
 				-webkit-transition: -webkit-transform 0.5s ease;
 				-ms-transition: -ms-transform 0.5s ease;
 				transition: transform 0.5s ease;
+				margin-top: 44px;
 				padding-bottom: 1px;
 			}
 


### PR DESCRIPTION
Fix issue with mobile not being able to see the top of the page under the nav bar.