### PR TITLE
add commissioner draft controls: captain rounds UI, edit-while-paused…

### DIFF
--- a/leagues/admin.py
+++ b/leagues/admin.py
@@ -1153,7 +1153,23 @@ class DraftTeamInline(admin.TabularInline):
         "captain_token_display",
     )
     readonly_fields = ("captain_token_display",)
-    autocomplete_fields = ("captain",)
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        if db_field.name == "captain":
+            session_pk = request.resolver_match.kwargs.get("object_id")
+            if session_pk:
+                try:
+                    session = DraftSession.objects.select_related("season").get(
+                        pk=session_pk
+                    )
+                    kwargs["queryset"] = SeasonSignup.objects.filter(
+                        season=session.season
+                    ).order_by("last_name", "first_name")
+                except DraftSession.DoesNotExist:
+                    kwargs["queryset"] = SeasonSignup.objects.none()
+            else:
+                kwargs["queryset"] = SeasonSignup.objects.none()
+        return super().formfield_for_foreignkey(db_field, request=request, **kwargs)
 
     def captain_token_display(self, obj):
         if not obj.pk:

--- a/leagues/draft_views.py
+++ b/leagues/draft_views.py
@@ -151,7 +151,8 @@ def _session_state_payload(session):
     teams_data = []
     for team in teams:
         picks_by_round = {}
-        has_goalie = False
+        # A goalie-captain counts even before their auto-pick round fires.
+        has_goalie = team.captain.is_goalie
         for pick in team.draft_picks.all():
             payload = _signup_payload(pick.signup)
             payload["is_captain_pick"] = pick.is_auto_captain
@@ -459,7 +460,12 @@ def draw_positions(request, session_pk, token):
         session.signups_open = False
         session.save(update_fields=["signups_open"])
 
-    # Broadcast via channels
+    # Broadcast the new DRAW state so all clients update state.state before
+    # the overlay animation completes — the commissioner's panel will then
+    # correctly render the captain-rounds UI when the overlay is closed.
+    _broadcast_state_change(session)
+
+    # Broadcast the reveal order separately so clients can animate the draw.
     from channels.layers import get_channel_layer
     from asgiref.sync import async_to_sync
 
@@ -498,6 +504,27 @@ def advance_state(request, session_pk, token):
         return JsonResponse({"error": "No transition available."}, status=400)
 
     update_fields = ["state"]
+
+    # Require every team to have a captain_draft_round before going active.
+    # Captains are excluded from the available player pool and can only be
+    # drafted via the auto-captain mechanism, so a missing round means they
+    # would never be picked.
+    if (
+        next_state == DraftSession.STATE_ACTIVE
+        and session.state == DraftSession.STATE_DRAW
+    ):
+        missing = session.teams.filter(captain_draft_round__isnull=True).select_related(
+            "captain"
+        )
+        if missing.exists():
+            names = ", ".join(t.captain.full_name for t in missing)
+            return JsonResponse(
+                {
+                    "error": f"Captain round not set for: {names}. "
+                    "Set a draft round for every captain before starting."
+                },
+                status=400,
+            )
 
     # Close signups when the draft first goes active from the draw phase
     if (
@@ -650,9 +677,11 @@ def make_pick(request, session_pk):
     picking_team = None
 
     if captain_token:
-        picking_team = DraftTeam.objects.filter(
-            session=session, captain_token=captain_token
-        ).first()
+        picking_team = (
+            DraftTeam.objects.select_related("captain")
+            .filter(session=session, captain_token=captain_token)
+            .first()
+        )
         if not picking_team:
             return JsonResponse({"error": "Invalid captain token."}, status=403)
     elif not is_commissioner:
@@ -709,11 +738,19 @@ def make_pick(request, session_pk):
         )
 
     if signup.primary_position == SeasonSignup.POSITION_GOALIE:
-        team_already_has_goalie = DraftPick.objects.filter(
-            session=session,
-            team=picking_team,
-            signup__primary_position=SeasonSignup.POSITION_GOALIE,
-        ).exists()
+        # A goalie-captain counts as the team's goalie even before their
+        # auto-pick round fires, so block any additional goalie pick.
+        captain_is_goalie = (
+            picking_team.captain.primary_position == SeasonSignup.POSITION_GOALIE
+        )
+        team_already_has_goalie = (
+            captain_is_goalie
+            or DraftPick.objects.filter(
+                session=session,
+                team=picking_team,
+                signup__primary_position=SeasonSignup.POSITION_GOALIE,
+            ).exists()
+        )
         if team_already_has_goalie:
             return JsonResponse(
                 {"error": f"{picking_team.team_name} already has a goalie."},
@@ -932,9 +969,10 @@ def swap_pick(request, session_pk, token):
 
     session = get_object_or_404(DraftSession, pk=session_pk, commissioner_token=token)
 
-    if session.state != DraftSession.STATE_COMPLETE:
+    if session.state not in (DraftSession.STATE_COMPLETE, DraftSession.STATE_PAUSED):
         return JsonResponse(
-            {"error": "Can only edit picks after draft is complete."}, status=400
+            {"error": "Can only edit picks when the draft is paused or complete."},
+            status=400,
         )
 
     pick_id = request.POST.get("pick_id")
@@ -998,6 +1036,64 @@ def swap_pick(request, session_pk, token):
             pick_a.signup = new_signup
             pick_a.is_auto_captain = False
             pick_a.save(update_fields=["signup", "is_auto_captain"])
+
+    _broadcast_state_change(session)
+    return JsonResponse({"success": True, "state": _session_state_payload(session)})
+
+
+# ---------------------------------------------------------------------------
+# Commissioner: set captain draft rounds (during setup or draw phase)
+# ---------------------------------------------------------------------------
+
+
+@require_POST
+def set_captain_rounds(request, session_pk, token):
+    """
+    Set the captain_draft_round for each team.  Only allowed before the draft
+    goes active (setup or draw state).
+
+    POST body (JSON): {"rounds": {"<team_pk>": <round_number_or_null>, ...}}
+    """
+    import json as _json
+
+    session = get_object_or_404(DraftSession, pk=session_pk, commissioner_token=token)
+
+    if session.state not in (DraftSession.STATE_SETUP, DraftSession.STATE_DRAW):
+        return JsonResponse(
+            {"error": "Captain rounds can only be set before the draft starts."},
+            status=400,
+        )
+
+    try:
+        body = _json.loads(request.body)
+        rounds_map = body.get("rounds", {})
+    except (_json.JSONDecodeError, AttributeError):
+        return JsonResponse({"error": "Invalid JSON body."}, status=400)
+
+    teams = {str(t.pk): t for t in session.teams.all()}
+    num_rounds = session.num_rounds
+
+    for team_pk_str, round_val in rounds_map.items():
+        team = teams.get(team_pk_str)
+        if not team:
+            continue
+        if round_val is None:
+            team.captain_draft_round = None
+        else:
+            try:
+                r = int(round_val)
+            except (TypeError, ValueError):
+                return JsonResponse(
+                    {"error": f"Invalid round value for team {team_pk_str}."},
+                    status=400,
+                )
+            if r < 1 or r > num_rounds:
+                return JsonResponse(
+                    {"error": f"Round {r} is out of range (1–{num_rounds})."},
+                    status=400,
+                )
+            team.captain_draft_round = r
+        team.save(update_fields=["captain_draft_round"])
 
     _broadcast_state_change(session)
     return JsonResponse({"success": True, "state": _session_state_payload(session)})

--- a/leagues/management/commands/import_draft_results.py
+++ b/leagues/management/commands/import_draft_results.py
@@ -571,7 +571,20 @@ class Command(BaseCommand):
                 continue
 
             pick_number = captain_names.index(cap_name)
-            is_captain_pick = player == captain_players.get(cap_name)
+            matched_captain = captain_players.get(cap_name)
+            if matched_captain is not None:
+                is_captain_pick = player == matched_captain
+            else:
+                # Captain header wasn't resolved to a Player (ambiguous or
+                # first-name-only like "Jesse", "Mike E", "Kenny").
+                # Fall back: check whether the player's first name is a
+                # case-insensitive prefix match against the header token —
+                # catches "Kenny"→"Ken", "Mike E"→"Mike", "Jesse"→"Jesse".
+                cap_prefix = cap_name.strip().split()[0].lower()
+                p_first = player.first_name.strip().lower()
+                is_captain_pick = cap_prefix.startswith(p_first) or p_first.startswith(
+                    cap_prefix
+                )
             DraftPick.objects.create(
                 session=session,
                 team=team,

--- a/leagues/templates/leagues/draft_board.html
+++ b/leagues/templates/leagues/draft_board.html
@@ -807,7 +807,7 @@
     {% if session.state == 'setup' %}
       <button class="btn btn-draw" onclick="triggerDraw()">Draw Positions Now</button>
     {% elif session.state == 'draw' %}
-      <button class="btn btn-primary" onclick="advanceState()" disabled>Start Draft</button>
+      <span style="color:#aaa;font-size:0.9rem;">Loading captain rounds…</span>
     {% elif session.state == 'active' %}
       <button class="btn btn-warning" onclick="advanceState()">Pause Draft</button>
       <button class="btn btn-danger" onclick="undoPick()">Undo Last Pick</button>
@@ -993,7 +993,12 @@ const WS_MAX_DELAY = 30000;
 function handleWsMessage(e) {
   const msg = JSON.parse(e.data);
   if (msg.type === 'state_update') {
+    const prevState = state ? state.state : null;
     state = msg.state;
+    // Close the draw overlay on all clients when the draft goes active.
+    if (prevState === 'draw' && state.state === 'active') {
+      document.getElementById('draw-overlay').classList.remove('visible');
+    }
     if (msg.undone_pick) showToast(`Undone: ${msg.undone_pick.player_name} (R${msg.undone_pick.round} P${msg.undone_pick.pick})`);
     if (msg.pick) showToast(`${msg.pick.team_name} picks ${msg.pick.player.full_name}`);
     if (msg.randomized_round_reveal) showRoundRevealOverlay(msg.randomized_round_reveal);
@@ -1379,6 +1384,33 @@ function applyResponseState(data) {
 }
 
 function advanceState() {
+  // Before DRAW → ACTIVE: save any round values currently in the inputs,
+  // then advance. This lets "Start Draft" work without a separate "Save Rounds"
+  // click. The server enforces that all rounds must be set before going active.
+  if (state.state === 'draw') {
+    const inputs = document.querySelectorAll('.captain-round-input');
+    if (inputs.length) {
+      const rounds = {};
+      for (const inp of inputs) {
+        const val = inp.value.trim();
+        rounds[inp.dataset.teamPk] = val === '' ? null : parseInt(val, 10);
+      }
+      fetch(`/draft/${SESSION_PK}/captain-rounds/${COMMISSIONER_TOKEN}/`, {
+        method: 'POST',
+        headers: { 'X-CSRFToken': getCsrf(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rounds }),
+      }).then(r => r.json()).then(d => {
+        if (d.error) { showToast(d.error, true); return; }
+        applyResponseState(d);
+        _doAdvance();
+      }).catch(() => showToast('Network error — could not save rounds.', true));
+      return;
+    }
+  }
+  _doAdvance();
+}
+
+function _doAdvance() {
   fetch(`/draft/${SESSION_PK}/advance/${COMMISSIONER_TOKEN}/`, {
     method: 'POST',
     headers: { 'X-CSRFToken': getCsrf() },
@@ -1425,13 +1457,52 @@ function updateCommissionerButtons() {
   if (s === 'setup') {
     html = `<button class="btn btn-draw" onclick="triggerDraw()">Draw Positions Now</button>`;
   } else if (s === 'draw') {
-    html = `<span style="color:#aaa;font-size:0.9rem;">Positions drawn — close the overlay to start the draft.</span>`;
+    const sorted = [...state.teams].sort((a, b) => (a.draft_position || 99) - (b.draft_position || 99));
+    const rows = sorted.map(t => {
+      const cur = t.captain_draft_round || '';
+      return `<tr>
+        <td style="padding:3px 8px;text-align:center;font-weight:600;">${t.draft_position || '?'}</td>
+        <td style="padding:3px 8px;">${t.captain_name}</td>
+        <td style="padding:3px 8px;">${t.team_name}</td>
+        <td style="padding:3px 8px;text-align:center;">
+          <input type="number" min="1" max="{{ session.num_rounds }}"
+            data-team-pk="${t.id}"
+            class="captain-round-input"
+            value="${cur}"
+            style="width:54px;padding:2px 4px;border:1px solid #555;border-radius:3px;background:#1a1a1a;color:#eee;text-align:center;">
+        </td>
+      </tr>`;
+    }).join('');
+    html = `
+      <div id="captain-rounds-panel" style="display:flex;flex-direction:column;gap:6px;width:100%;">
+        <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;">
+          <span style="font-weight:600;color:#eee;">Set Captain Draft Rounds</span>
+          <span style="font-size:0.78rem;color:#aaa;">Enter the round each captain is auto-drafted onto their team (leave blank to skip).</span>
+          <button class="btn btn-primary" onclick="saveCaptainRounds()" style="padding:4px 14px;">Save Rounds</button>
+          <button class="btn btn-success" onclick="advanceState()" style="padding:4px 14px;">Start Draft</button>
+        </div>
+        <table style="border-collapse:collapse;font-size:0.82rem;color:#ccc;">
+          <thead><tr>
+            <th style="padding:2px 8px;color:#aaa;font-weight:400;">Pick #</th>
+            <th style="padding:2px 8px;color:#aaa;font-weight:400;">Captain</th>
+            <th style="padding:2px 8px;color:#aaa;font-weight:400;">Team</th>
+            <th style="padding:2px 8px;color:#aaa;font-weight:400;">Captain Round</th>
+          </tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>`;
   } else if (s === 'active') {
     html = `<button class="btn btn-warning" onclick="advanceState()">Pause Draft</button>
             <button class="btn btn-danger" onclick="undoPick()">Undo Last Pick</button>`;
   } else if (s === 'paused') {
-    html = `<button class="btn btn-primary" onclick="advanceState()">Resume Draft</button>
-            <button class="btn btn-danger" onclick="undoPick()">Undo Last Pick</button>`;
+    if (editMode) {
+      html = `<button class="btn btn-primary" onclick="advanceState()">Resume Draft</button>
+              <button class="btn btn-warning" onclick="toggleEditMode()" style="margin-left:8px;">Done Editing</button>`;
+    } else {
+      html = `<button class="btn btn-primary" onclick="advanceState()">Resume Draft</button>
+              <button class="btn btn-danger" onclick="undoPick()">Undo Last Pick</button>
+              <button class="btn" onclick="toggleEditMode()" style="margin-left:8px;background:#555;color:#fff;">Edit Picks</button>`;
+    }
   } else if (s === 'complete') {
     if (editMode) {
       html = `<button class="btn btn-success" onclick="finalizeDraft()">Re-finalize &amp; Update Rosters</button>`
@@ -1473,6 +1544,25 @@ function finalizeDraft() {
 function toggleEditMode() {
   editMode = !editMode;
   render();
+}
+
+function saveCaptainRounds() {
+  const inputs = document.querySelectorAll('.captain-round-input');
+  const rounds = {};
+  for (const inp of inputs) {
+    const pk = inp.dataset.teamPk;
+    const val = inp.value.trim();
+    rounds[pk] = val === '' ? null : parseInt(val, 10);
+  }
+  fetch(`/draft/${SESSION_PK}/captain-rounds/${COMMISSIONER_TOKEN}/`, {
+    method: 'POST',
+    headers: { 'X-CSRFToken': getCsrf(), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ rounds }),
+  }).then(r => r.json()).then(d => {
+    if (d.error) { showToast(d.error, true); return; }
+    showToast('Captain rounds saved.');
+    applyResponseState(d);
+  }).catch(() => showToast('Network error — could not save rounds.', true));
 }
 
 function resetDraft() {
@@ -1586,7 +1676,8 @@ function closeDraw() {
   drawMode = 'draw';
   document.getElementById('draw-overlay-title').textContent = 'Draft Position Draw';
   document.getElementById('draw-done-btn').textContent = 'Start Draft';
-  if (wasDrawMode && IS_COMMISSIONER) advanceState();
+  // Do not auto-advance — commissioner sets captain rounds first, then clicks Start Draft.
+  if (wasDrawMode && IS_COMMISSIONER) updateCommissionerButtons();
 }
 
 function showRoundRevealOverlay(data) {

--- a/leagues/test_draft.py
+++ b/leagues/test_draft.py
@@ -552,9 +552,16 @@ class AdvanceStateViewTests(DraftTestBase):
         self.session.refresh_from_db()
         self.assertEqual(self.session.state, DraftSession.STATE_DRAW)
 
+    def _set_all_captain_rounds(self):
+        """Give every team a captain_draft_round so DRAW→ACTIVE succeeds."""
+        for i, team in enumerate(self.session.teams.all(), start=1):
+            team.captain_draft_round = i
+            team.save(update_fields=["captain_draft_round"])
+
     def test_draw_to_active(self):
         self.session.state = DraftSession.STATE_DRAW
         self.session.save(update_fields=["state"])
+        self._set_all_captain_rounds()
         self.client.post(self._advance_url())
         self.session.refresh_from_db()
         self.assertEqual(self.session.state, DraftSession.STATE_ACTIVE)
@@ -563,9 +570,34 @@ class AdvanceStateViewTests(DraftTestBase):
         self.session.state = DraftSession.STATE_DRAW
         self.session.signups_open = True
         self.session.save(update_fields=["state", "signups_open"])
+        self._set_all_captain_rounds()
         self.client.post(self._advance_url())
         self.session.refresh_from_db()
         self.assertFalse(self.session.signups_open)
+
+    def test_draw_to_active_blocked_when_captain_round_missing(self):
+        self.session.state = DraftSession.STATE_DRAW
+        self.session.save(update_fields=["state"])
+        # teams have no captain_draft_round (default null)
+        response = self.client.post(self._advance_url())
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.content)
+        self.assertIn("captain round not set", data["error"].lower())
+
+    def test_draw_to_active_blocked_when_one_captain_round_missing(self):
+        self.session.state = DraftSession.STATE_DRAW
+        self.session.save(update_fields=["state"])
+        # Set rounds for only two of three teams
+        teams = list(self.session.teams.all())
+        teams[0].captain_draft_round = 1
+        teams[0].save(update_fields=["captain_draft_round"])
+        teams[1].captain_draft_round = 2
+        teams[1].save(update_fields=["captain_draft_round"])
+        # teams[2] left null
+        response = self.client.post(self._advance_url())
+        self.assertEqual(response.status_code, 400)
+        self.session.refresh_from_db()
+        self.assertEqual(self.session.state, DraftSession.STATE_DRAW)
 
     def test_active_to_paused(self):
         self._activate()
@@ -687,6 +719,33 @@ class MakePickViewTests(DraftTestBase):
                 session=self.session, signup=self.cap1, team=self.team1
             ).exists()
         )
+
+    def test_goalie_captain_blocks_second_goalie_before_auto_pick(self):
+        # Make cap1 a goalie captain. Even before their auto-pick round fires,
+        # the team should not be allowed to draft another goalie.
+        self.cap1.primary_position = SeasonSignup.POSITION_GOALIE
+        self.cap1.save(update_fields=["primary_position"])
+        self.team1.captain_draft_round = 2
+        self.team1.save(update_fields=["captain_draft_round"])
+        # Round 1, team1's turn — try to draft a goalie
+        response = self._post_pick(
+            self.goalie1.pk, commissioner_token=self.session.commissioner_token
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("goalie", json.loads(response.content)["error"])
+
+    def test_goalie_captain_has_goalie_true_in_payload(self):
+        self.cap1.primary_position = SeasonSignup.POSITION_GOALIE
+        self.cap1.save(update_fields=["primary_position"])
+        payload = _session_state_payload(self.session)
+        team1_data = next(t for t in payload["teams"] if t["id"] == self.team1.pk)
+        self.assertTrue(team1_data["has_goalie"])
+
+    def test_non_goalie_captain_has_goalie_false_in_payload(self):
+        # cap1 is center by default (from DraftTestBase)
+        payload = _session_state_payload(self.session)
+        team1_data = next(t for t in payload["teams"] if t["id"] == self.team1.pk)
+        self.assertFalse(team1_data["has_goalie"])
 
     def test_second_goalie_to_same_team_returns_400(self):
         # Team1 picks goalie1, then tries to pick goalie2
@@ -916,13 +975,22 @@ class SwapPickViewTests(DraftTestBase):
         pick.refresh_from_db()
         self.assertEqual(pick.signup, self.cap1)
 
-    def test_swap_requires_draft_complete(self):
+    def test_swap_allowed_when_paused(self):
+        self.session.state = DraftSession.STATE_PAUSED
+        self.session.save(update_fields=["state"])
+        pick = self._make_pick(self.team1, self.players[0], 1, 0)
+        response = self._swap(pick.pk, self.players[1].pk)
+        self.assertEqual(response.status_code, 200)
+        pick.refresh_from_db()
+        self.assertEqual(pick.signup, self.players[1])
+
+    def test_swap_blocked_when_active(self):
         self.session.state = DraftSession.STATE_ACTIVE
         self.session.save(update_fields=["state"])
         pick = self._make_pick(self.team1, self.players[0], 1, 0)
         response = self._swap(pick.pk, self.players[1].pk)
         self.assertEqual(response.status_code, 400)
-        self.assertIn("complete", json.loads(response.content)["error"])
+        self.assertIn("paused or complete", json.loads(response.content)["error"])
 
     def test_swap_wrong_token_returns_404(self):
         import uuid
@@ -993,6 +1061,110 @@ class ResetDraftViewTests(DraftTestBase):
         url = reverse("draft_reset", args=[self.session.pk, uuid.uuid4()])
         response = self.client.post(url)
         self.assertEqual(response.status_code, 404)
+
+
+# ---------------------------------------------------------------------------
+# View: set_captain_rounds
+# ---------------------------------------------------------------------------
+
+
+class SetCaptainRoundsViewTests(DraftTestBase):
+    def setUp(self):
+        super().setUp()
+        # Put session in DRAW state (positions already drawn by DraftTestBase)
+        self.session.state = DraftSession.STATE_DRAW
+        self.session.save(update_fields=["state"])
+        self._broadcast_patcher = patch("leagues.draft_views._broadcast_state_change")
+        self._broadcast_patcher.start()
+
+    def tearDown(self):
+        self._broadcast_patcher.stop()
+        super().tearDown()
+
+    def _url(self):
+        return reverse(
+            "draft_set_captain_rounds",
+            args=[self.session.pk, self.session.commissioner_token],
+        )
+
+    def _post(self, rounds_map):
+        return self.client.post(
+            self._url(),
+            data=json.dumps({"rounds": rounds_map}),
+            content_type="application/json",
+        )
+
+    def test_sets_rounds_in_draw_state(self):
+        response = self._post(
+            {str(self.team1.pk): 1, str(self.team2.pk): 2, str(self.team3.pk): 3}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.team1.refresh_from_db()
+        self.team2.refresh_from_db()
+        self.team3.refresh_from_db()
+        self.assertEqual(self.team1.captain_draft_round, 1)
+        self.assertEqual(self.team2.captain_draft_round, 2)
+        self.assertEqual(self.team3.captain_draft_round, 3)
+
+    def test_sets_rounds_in_setup_state(self):
+        self.session.state = DraftSession.STATE_SETUP
+        self.session.save(update_fields=["state"])
+        response = self._post({str(self.team1.pk): 2})
+        self.assertEqual(response.status_code, 200)
+        self.team1.refresh_from_db()
+        self.assertEqual(self.team1.captain_draft_round, 2)
+
+    def test_clears_round_when_null(self):
+        self.team1.captain_draft_round = 1
+        self.team1.save(update_fields=["captain_draft_round"])
+        response = self._post({str(self.team1.pk): None})
+        self.assertEqual(response.status_code, 200)
+        self.team1.refresh_from_db()
+        self.assertIsNone(self.team1.captain_draft_round)
+
+    def test_rejects_round_out_of_range(self):
+        response = self._post({str(self.team1.pk): 99})
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.content)
+        self.assertIn("out of range", data["error"])
+
+    def test_rejects_round_zero(self):
+        response = self._post({str(self.team1.pk): 0})
+        self.assertEqual(response.status_code, 400)
+
+    def test_rejects_when_active(self):
+        self.session.state = DraftSession.STATE_ACTIVE
+        self.session.save(update_fields=["state"])
+        response = self._post({str(self.team1.pk): 1})
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.content)
+        self.assertIn("before the draft starts", data["error"])
+
+    def test_wrong_token_returns_404(self):
+        import uuid
+
+        url = reverse("draft_set_captain_rounds", args=[self.session.pk, uuid.uuid4()])
+        response = self.client.post(
+            url,
+            data=json.dumps({"rounds": {str(self.team1.pk): 1}}),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_not_allowed(self):
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, 405)
+
+    def test_returns_updated_state_payload(self):
+        response = self._post({str(self.team1.pk): 1})
+        data = json.loads(response.content)
+        self.assertIn("state", data)
+        team_data = next(t for t in data["state"]["teams"] if t["id"] == self.team1.pk)
+        self.assertEqual(team_data["captain_draft_round"], 1)
+
+    def test_ignores_unknown_team_pk(self):
+        response = self._post({"99999": 1})
+        self.assertEqual(response.status_code, 200)
 
 
 # ---------------------------------------------------------------------------

--- a/leagues/urls.py
+++ b/leagues/urls.py
@@ -18,6 +18,7 @@ from .draft_views import (
     finalize_draft,
     swap_pick,
     reset_draft,
+    set_captain_rounds,
 )
 
 urlpatterns = [
@@ -104,5 +105,10 @@ urlpatterns = [
         "draft/<int:session_pk>/reset/<uuid:token>/",
         reset_draft,
         name="draft_reset",
+    ),
+    path(
+        "draft/<int:session_pk>/captain-rounds/<uuid:token>/",
+        set_captain_rounds,
+        name="draft_set_captain_rounds",
     ),
 ]


### PR DESCRIPTION
…, and bug fixes

Commissioner UX:
- Add captain-rounds panel in draw phase so commissioner can set each captain's auto-pick round directly on the board after positions are drawn
- "Start Draft" now saves rounds and advances state atomically — no separate "Save Rounds" click required
- Add "Edit Picks" button in paused state so commissioner can swap picks mid-draft without undoing one-by-one
- Fix draw_positions to broadcast state_update so clients see draw→active transition and the captain-rounds panel renders correctly after overlay closes
- Close draw overlay on all connected clients when commissioner starts draft

Validation:
- Block DRAW→ACTIVE transition if any captain is missing a draft round (server + client enforcement)
- Restrict admin captain dropdown to signups for that session's season only

Bug fixes:
- Goalie captain counts as team's goalie before auto-pick fires — blocks drafting a second goalie and correctly sets has_goalie in state payload
- Fix is_auto_captain=False on 5 imported Fall 2025 captain picks whose headers were first-name-only (Jesse, Kenny, Mylan, Grant, Mike E); add prefix-match fallback in import_draft_results for future imports
- Fix missing select_related("captain") on captain-token pick path