### PR TITLE
safeguard local→prod push and label current season on draft archive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,21 +156,20 @@ This applies to:
 
 ### Pushing local → production
 
-```bash
-# Backup local first
-./scripts/backup_db.sh
+**This is destructive and rare.** Use only when you intentionally want to overwrite production data (e.g. after a data migration or seeding exercise that you fully tested locally).
 
-# Dump local, wipe prod, restore
-LOCAL_DUMP="/tmp/local_push_$(date +%Y%m%d_%H%M%S).sql"
-pg_dump --no-acl --no-owner dcstreethockey > "$LOCAL_DUMP"
-psql "$RENDER_EXTERNAL_DATABASE_URL" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
-psql "$RENDER_EXTERNAL_DATABASE_URL" < "$LOCAL_DUMP"
+```bash
+./scripts/push_local_to_render.sh --confirm
 ```
+
+The script requires `--confirm` AND an interactive confirmation phrase. **Never run the underlying `psql` commands directly** — always go through this script so the safeguards are enforced.
 
 ### Pulling production → local
 
+This happens automatically at the start of each Claude Code session (at most once per 24 hours via the `UserPromptSubmit` hook). To trigger it manually:
+
 ```bash
-./scripts/restore_prod_to_local.sh  # set PROD_DB_URL=$RENDER_EXTERNAL_DATABASE_URL
+db_migration_scripts/sync_render_to_local.sh
 ```
 
 ---

--- a/leagues/templates/leagues/draft_archive.html
+++ b/leagues/templates/leagues/draft_archive.html
@@ -31,6 +31,9 @@
   .da-card.da-live {
     border-left: 4px solid #c82333;
   }
+  .da-card.da-current-card {
+    border-left: 4px solid #28a745;
+  }
   .da-card.da-champion-card {
     border-left: 4px solid #b7860b;
   }
@@ -70,6 +73,7 @@
   .da-badge-draw    { background: #f0e6ff; color: #4a0080; }
   .da-badge-paused  { background: #fff3cd; color: #856404; }
   .da-badge-complete{ background: #cce5ff; color: #004085; }
+  .da-badge-current { background: #d4edda; color: #155724; }
 
   /* Live dot for active/draw sessions */
   .da-live-dot {
@@ -220,6 +224,7 @@
           {% for session, champ in sessions_with_champ %}
           <div class="da-card
             {% if session.state == 'active' or session.state == 'draw' %}da-live
+            {% elif forloop.first and session.state == 'complete' %}da-current-card
             {% elif champ %}da-champion-card{% endif %}">
 
             <div class="da-card-main">
@@ -227,9 +232,13 @@
               <!-- Season header row -->
               <div class="da-season">{{ session.season }} Wednesday Draft</div>
               <div class="da-meta">
-                <span class="da-badge da-badge-{{ session.state }}">
+                <span class="da-badge
+                  {% if session.state == 'active' or session.state == 'draw' %}da-badge-active
+                  {% elif forloop.first and session.state == 'complete' %}da-badge-current
+                  {% else %}da-badge-{{ session.state }}{% endif %}">
                   {% if session.state == 'active' or session.state == 'draw' %}
                     <span class="da-live-dot"></span>Live
+                  {% elif forloop.first and session.state == 'complete' %}Current Season
                   {% elif session.state == 'paused' %}Paused
                   {% elif session.state == 'complete' %}Complete
                   {% else %}{{ session.state }}

--- a/scripts/push_local_to_render.sh
+++ b/scripts/push_local_to_render.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# push_local_to_render.sh — Overwrite the Render production database with your
+# local database.
+#
+# THIS IS DESTRUCTIVE AND IRREVERSIBLE. Production data will be replaced with
+# your local database. Use only after deliberate, intentional testing.
+#
+# Usage:
+#   ./scripts/push_local_to_render.sh --confirm
+#
+# The --confirm flag is required. Without it the script exits immediately.
+# You will also be prompted to type a confirmation phrase interactively.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DB_NAME="${DB_NAME:-dcstreethockey}"
+DB_USER="${DB_USER:-dcstreethockey}"
+
+# ---------------------------------------------------------------------------
+# Require --confirm flag
+# ---------------------------------------------------------------------------
+CONFIRMED=0
+for arg in "$@"; do
+    if [[ "$arg" == "--confirm" ]]; then
+        CONFIRMED=1
+    fi
+done
+
+if [[ "$CONFIRMED" -eq 0 ]]; then
+    echo ""
+    echo "  ERROR: --confirm flag is required."
+    echo ""
+    echo "  This script overwrites the Render PRODUCTION database with your"
+    echo "  local database. It is destructive and cannot be undone."
+    echo ""
+    echo "  If you are sure, run:"
+    echo "    ./scripts/push_local_to_render.sh --confirm"
+    echo ""
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Require RENDER_EXTERNAL_DATABASE_URL
+# ---------------------------------------------------------------------------
+if [[ -z "${RENDER_EXTERNAL_DATABASE_URL:-}" ]]; then
+    echo "ERROR: RENDER_EXTERNAL_DATABASE_URL is not set."
+    echo "  It should be exported in ~/.zshrc."
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Loud warning banner
+# ---------------------------------------------------------------------------
+echo ""
+echo "  ╔══════════════════════════════════════════════════════════════╗"
+echo "  ║       WARNING: YOU ARE ABOUT TO OVERWRITE PRODUCTION        ║"
+echo "  ║                                                              ║"
+echo "  ║  Local database  →  Render production database              ║"
+echo "  ║                                                              ║"
+echo "  ║  ALL production data will be PERMANENTLY REPLACED with      ║"
+echo "  ║  your local database. This cannot be undone.                ║"
+echo "  ╚══════════════════════════════════════════════════════════════╝"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Interactive confirmation — must type exact phrase
+# ---------------------------------------------------------------------------
+REQUIRED_PHRASE="overwrite production"
+echo "  Type exactly:  overwrite production"
+echo "  (anything else aborts)"
+echo ""
+read -r -p "  > " USER_INPUT
+
+if [[ "$USER_INPUT" != "$REQUIRED_PHRASE" ]]; then
+    echo ""
+    echo "  Aborted. Nothing was changed."
+    exit 1
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Step 1: Backup local database first
+# ---------------------------------------------------------------------------
+echo "=== Step 1: Backing up local database ==="
+"$SCRIPT_DIR/backup_db.sh"
+
+# ---------------------------------------------------------------------------
+# Step 2: Dump local database
+# ---------------------------------------------------------------------------
+LOCAL_DUMP="/tmp/local_push_$(date +%Y%m%d_%H%M%S).sql"
+echo ""
+echo "=== Step 2: Dumping local database '$DB_NAME' ==="
+pg_dump --no-acl --no-owner -U "$DB_USER" "$DB_NAME" > "$LOCAL_DUMP"
+echo "  Done. $(du -sh "$LOCAL_DUMP" | cut -f1) written to $LOCAL_DUMP"
+
+# ---------------------------------------------------------------------------
+# Step 3: Wipe and restore production
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Step 3: Overwriting Render production database ==="
+psql "$RENDER_EXTERNAL_DATABASE_URL" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+psql "$RENDER_EXTERNAL_DATABASE_URL" < "$LOCAL_DUMP"
+echo "  Done."
+
+# ---------------------------------------------------------------------------
+# Step 4: Run migrations on production
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Step 4: Running migrations on production ==="
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [[ -z "$PYTHON_BIN" ]]; then
+    if [[ -x "$(pwd)/venv/bin/python" ]]; then
+        PYTHON_BIN="$(pwd)/venv/bin/python"
+    else
+        PYTHON_BIN="python"
+    fi
+fi
+DATABASE_URL="$RENDER_EXTERNAL_DATABASE_URL" \
+    "$PYTHON_BIN" manage.py migrate --settings=dcstreethockey.settings.production
+echo "  Done."
+
+echo ""
+echo "=== Production database has been replaced with your local database. ==="
+echo "  Local dump saved at: $LOCAL_DUMP"


### PR DESCRIPTION
- Replace raw psql push commands in CLAUDE.md with scripts/push_local_to_render.sh, which requires --confirm flag and interactive phrase to prevent accidental overwrites
- Update CLAUDE.md to clarify prod→local sync is automatic via Claude hook
- Show "Current Season" green badge on the most recent draft session instead of the blue "Complete" badge, so active seasons are visually distinct from past ones