### PR TITLE
fix duplicate Player records when signup name differs from profile

### DIFF
--- a/leagues/draft_views.py
+++ b/leagues/draft_views.py
@@ -390,11 +390,14 @@ def draft_signup(request, season_pk):
             error = "Please answer the captain interest question."
 
         if not error:
-            # Try to link to an existing Player record
+            # Try to link to an existing Player record — first by name, then by
+            # email as a fallback (handles nicknames like Mike vs. Michael).
             linked_player = Player.objects.filter(
                 first_name__iexact=first_name,
                 last_name__iexact=last_name,
             ).first()
+            if linked_player is None and email:
+                linked_player = Player.objects.filter(email__iexact=email).first()
 
             existing_email = SeasonSignup.objects.filter(
                 season=season,
@@ -1065,10 +1068,19 @@ def finalize_draft(request, session_pk, token):
                 if signup.linked_player:
                     player = signup.linked_player
                 else:
-                    player, _ = Player.objects.get_or_create(
-                        first_name=signup.first_name,
-                        last_name=signup.last_name,
-                    )
+                    # Try email before falling back to get_or_create by name,
+                    # so a nickname mismatch (Mike vs. Michael) doesn't create
+                    # a duplicate Player record.
+                    player = None
+                    if signup.email:
+                        player = Player.objects.filter(
+                            email__iexact=signup.email
+                        ).first()
+                    if player is None:
+                        player, _ = Player.objects.get_or_create(
+                            first_name=signup.first_name,
+                            last_name=signup.last_name,
+                        )
                     signup.linked_player = player
                     signup.save(update_fields=["linked_player"])
 

--- a/leagues/test_draft.py
+++ b/leagues/test_draft.py
@@ -411,6 +411,40 @@ class DraftSignupViewTests(DraftTestBase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "email address is already signed up")
 
+    def test_signup_links_player_by_email_when_name_differs(self):
+        """Email-matched Player is linked even when the signup name doesn't match exactly."""
+        player = Player.objects.create(
+            first_name="Michael",
+            last_name="Smith",
+            email="mike@example.com",
+            is_active=True,
+        )
+        data = self._valid_post_data(first="Mike", last="Smith")
+        data["email"] = "mike@example.com"
+        self.client.post(self._signup_url(), data)
+        signup = SeasonSignup.objects.get(season=self.season, email="mike@example.com")
+        self.assertEqual(signup.linked_player, player)
+
+    def test_signup_links_player_by_name_before_email(self):
+        """Exact name match takes precedence over email match."""
+        name_player = Player.objects.create(
+            first_name="Mike",
+            last_name="Jones",
+            email="other@example.com",
+            is_active=True,
+        )
+        Player.objects.create(
+            first_name="Somebody",
+            last_name="Else",
+            email="mike@example.com",
+            is_active=True,
+        )
+        data = self._valid_post_data(first="Mike", last="Jones")
+        data["email"] = "mike@example.com"
+        self.client.post(self._signup_url(), data)
+        signup = SeasonSignup.objects.get(season=self.season, email="mike@example.com")
+        self.assertEqual(signup.linked_player, name_player)
+
     def test_signups_closed_shows_closed_page(self):
         self.session.signups_open = False
         self.session.save(update_fields=["signups_open"])


### PR DESCRIPTION
Fall back to email matching when linking a SeasonSignup to an existing Player — both at signup time and during draft finalization. Prevents a new Player record from being created for someone who signed up as "Michael" when their profile says "Mike".