### PR TITLE
Add schedule manager with inline game editing and adding

### DIFF
--- a/leagues/admin.py
+++ b/leagues/admin.py
@@ -560,6 +560,199 @@ class MatchUpAdmin(admin.ModelAdmin):
     class Media:
         js = ("admin/js/stat_autofill_team.js",)
 
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "schedule/",
+                self.admin_site.admin_view(self.schedule_manager_view),
+                name="leagues_matchup_schedule_manager",
+            ),
+        ]
+        return custom_urls + urls
+
+    def schedule_manager_view(self, request):
+        import datetime as dt
+        from collections import defaultdict as _defaultdict
+
+        today = date.today()
+
+        # ------------------------------------------------------------------ #
+        # POST — save edits + create new matchups                             #
+        # ------------------------------------------------------------------ #
+        if request.method == "POST":
+            division_id = request.POST.get("division_id", "")
+            filter_date = request.POST.get("filter_date", "")
+            updated = 0
+            added = 0
+
+            # --- Update existing matchups ---
+            pks_raw = request.POST.get("matchup_pks", "")
+            matchup_pks = [int(pk) for pk in pks_raw.split(",") if pk.strip().isdigit()]
+            for matchup in MatchUp.objects.filter(pk__in=matchup_pks).select_related(
+                "week__division", "week__season"
+            ):
+                new_date_str = request.POST.get(f"m_{matchup.pk}_date", "")
+                new_time_str = request.POST.get(f"m_{matchup.pk}_time", "")
+                changed = False
+
+                if new_date_str:
+                    try:
+                        new_date_val = dt.datetime.strptime(
+                            new_date_str, "%Y-%m-%d"
+                        ).date()
+                    except ValueError:
+                        continue
+                    if new_date_val != matchup.week.date:
+                        week, _ = Week.objects.get_or_create(
+                            division=matchup.week.division,
+                            season=matchup.week.season,
+                            date=new_date_val,
+                            defaults={"is_cancelled": False},
+                        )
+                        matchup.week = week
+                        changed = True
+
+                if new_time_str:
+                    try:
+                        new_time_val = dt.datetime.strptime(
+                            new_time_str, "%H:%M"
+                        ).time()
+                    except ValueError:
+                        continue
+                    if new_time_val != matchup.time:
+                        matchup.time = new_time_val
+                        changed = True
+
+                if changed:
+                    matchup.save()
+                    updated += 1
+
+            # --- Create new matchups ---
+            new_row_count = int(request.POST.get("new_row_count", 0) or 0)
+            for i in range(new_row_count):
+                date_str = request.POST.get(f"new_{i}_date", "").strip()
+                time_str = request.POST.get(f"new_{i}_time", "").strip()
+                away_id = request.POST.get(f"new_{i}_away", "").strip()
+                home_id = request.POST.get(f"new_{i}_home", "").strip()
+                div_id = (
+                    request.POST.get(f"new_{i}_division_id", "").strip() or division_id
+                )
+                if not all([date_str, time_str, away_id, home_id, div_id]):
+                    continue
+                try:
+                    new_date_val = dt.datetime.strptime(date_str, "%Y-%m-%d").date()
+                    new_time_val = dt.datetime.strptime(time_str, "%H:%M").time()
+                    away_team = Team.objects.get(pk=int(away_id))
+                    home_team = Team.objects.get(pk=int(home_id))
+                    division_obj = Division.objects.get(pk=int(div_id))
+                except (ValueError, Team.DoesNotExist, Division.DoesNotExist):
+                    continue
+                season = (
+                    get_current_season_for_division(division_obj.pk)
+                    or get_current_season()
+                )
+                if not season:
+                    continue
+                week, _ = Week.objects.get_or_create(
+                    division=division_obj,
+                    season=season,
+                    date=new_date_val,
+                    defaults={"is_cancelled": False},
+                )
+                MatchUp.objects.create(
+                    week=week,
+                    time=new_time_val,
+                    awayteam=away_team,
+                    hometeam=home_team,
+                )
+                added += 1
+
+            # Build result message
+            parts = []
+            if added:
+                parts.append(f"{added} game{'s' if added != 1 else ''} added")
+            if updated:
+                parts.append(f"{updated} game{'s' if updated != 1 else ''} updated")
+            if parts:
+                messages.success(request, ", ".join(parts).capitalize() + ".")
+            else:
+                messages.info(request, "No changes were made.")
+
+            params = {}
+            if division_id:
+                params["division_id"] = division_id
+            if filter_date:
+                params["filter_date"] = filter_date
+            redirect_url = reverse("admin:leagues_matchup_schedule_manager")
+            if params:
+                redirect_url += "?" + urlencode(params)
+            return HttpResponseRedirect(redirect_url)
+
+        # ------------------------------------------------------------------ #
+        # GET — render filter + table                                          #
+        # ------------------------------------------------------------------ #
+        division_id = request.GET.get("division_id", "")
+        filter_date = request.GET.get("filter_date", "")
+
+        all_divisions = (
+            Division.objects.filter(week__date__gte=today)
+            .distinct()
+            .order_by("division")
+        )
+
+        matchups_by_date = {}
+        matchup_pks_str = ""
+
+        if division_id or filter_date:
+            qs = (
+                MatchUp.objects.filter(week__date__gte=today, is_cancelled=False)
+                .select_related(
+                    "hometeam", "awayteam", "week__division", "week__season"
+                )
+                .order_by("week__date", "time")
+            )
+            if division_id:
+                qs = qs.filter(week__division_id=division_id)
+            if filter_date:
+                qs = qs.filter(week__date=filter_date)
+
+            for m in qs:
+                matchups_by_date.setdefault(m.week.date, []).append(m)
+            matchup_pks_str = ",".join(
+                str(m.pk) for games in matchups_by_date.values() for m in games
+            )
+
+        # Teams grouped by division — used by JS to populate add-row dropdowns
+        teams_by_div = _defaultdict(list)
+        for team in (
+            Team.objects.filter(is_active=True)
+            .select_related("division")
+            .order_by("team_name")
+        ):
+            if team.division_id:
+                teams_by_div[str(team.division_id)].append(
+                    {"id": team.pk, "name": team.team_name}
+                )
+
+        context = {
+            **self.admin_site.each_context(request),
+            "title": "Manage Schedule",
+            "all_divisions": all_divisions,
+            "division_id": division_id,
+            "filter_date": filter_date,
+            "matchups_by_date": matchups_by_date,
+            "matchup_pks_str": matchup_pks_str,
+            "has_filters": bool(division_id or filter_date),
+            "has_results": bool(matchups_by_date),
+            "teams_by_division_json": json.dumps(dict(teams_by_div)),
+            "division_names_json": json.dumps(
+                {str(d.pk): str(d) for d in all_divisions}
+            ),
+            "opts": self.model._meta,
+        }
+        return render(request, "admin/leagues/matchup/schedule_manager.html", context)
+
     def lookup_allowed(self, lookup, value):
         if lookup in {"season_ids", "timeframe"}:
             return True

--- a/leagues/admin.py
+++ b/leagues/admin.py
@@ -38,6 +38,7 @@ from leagues.models import (
     DraftRound,
     DraftPick,
 )
+import json
 import logging
 from datetime import timedelta, date
 
@@ -521,11 +522,43 @@ class MatchUpAdmin(admin.ModelAdmin):
         kwargs["extra_context"] = extra_context
         return super().render_change_list(request, *args, **kwargs)
 
+    # "Save and add another" creates a blank new matchup, which is never the
+    # right action here (matchups are created via WeekAdmin). Remove it so the
+    # only choices are "Save" (done → home) and "Save and continue editing".
+    show_save_and_add_another = False
+
     def changelist_view(self, request, extra_context=None):
         redirect_url = _apply_default_matchup_filters(request, default_timeframe="past")
         if redirect_url:
             return redirect(redirect_url)
         return super().changelist_view(request, extra_context=extra_context)
+
+    def response_post_save_change(self, request, obj):
+        """After a plain 'Save', return to the admin home where the stats entry
+        widget and quick-cancel widget live — not the matchup changelist."""
+        return HttpResponseRedirect(reverse("admin:index"))
+
+    def change_view(self, request, object_id, form_url="", extra_context=None):
+        extra_context = extra_context or {}
+        try:
+            match = MatchUp.objects.select_related("hometeam", "awayteam").get(
+                pk=object_id
+            )
+            roster_entries = Roster.objects.filter(
+                team__in=[match.hometeam_id, match.awayteam_id]
+            ).values("player_id", "team_id")
+            player_team_map = {
+                str(r["player_id"]): str(r["team_id"]) for r in roster_entries
+            }
+            extra_context["player_team_map_json"] = json.dumps(player_team_map)
+        except MatchUp.DoesNotExist:
+            extra_context["player_team_map_json"] = "{}"
+        return super().change_view(
+            request, object_id, form_url=form_url, extra_context=extra_context
+        )
+
+    class Media:
+        js = ("admin/js/stat_autofill_team.js",)
 
     def lookup_allowed(self, lookup, value):
         if lookup in {"season_ids", "timeframe"}:

--- a/leagues/templatetags/admin_quick_cancel.py
+++ b/leagues/templatetags/admin_quick_cancel.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from datetime import date, timedelta
 
 from django import template
+from django.db.models import Count
 
 from leagues.models import MatchUp, Week
 
@@ -61,4 +62,50 @@ def quick_cancel_widget(context):
         "grouped_weeks": grouped,
         "today": today,
         "csrf_token": context.get("csrf_token"),
+    }
+
+
+@register.inclusion_tag("admin/stats_entry_widget.html")
+def stats_entry_widget():
+    today = date.today()
+    since = today - timedelta(days=7)
+
+    matchups = (
+        MatchUp.objects.filter(
+            week__date__range=(since, today),
+            is_cancelled=False,
+            week__is_cancelled=False,
+        )
+        .select_related("hometeam", "awayteam", "week__division")
+        .annotate(stat_count=Count("stat"))
+        .order_by("week__date", "week__division__division", "time")
+    )
+
+    # Group by date, then by division
+    date_buckets = defaultdict(lambda: defaultdict(list))
+    for m in matchups:
+        date_buckets[m.week.date][m.week.division].append(m)
+
+    grouped = {}
+    for game_date in sorted(date_buckets.keys(), reverse=True):
+        divisions = []
+        for division, games in sorted(
+            date_buckets[game_date].items(), key=lambda x: x[0].division
+        ):
+            divisions.append(
+                {
+                    "division": division,
+                    "games": games,
+                    "all_entered": all(g.stat_count > 0 for g in games),
+                    "any_missing": any(g.stat_count == 0 for g in games),
+                }
+            )
+        grouped[game_date] = {
+            "divisions": divisions,
+            "all_entered": all(d["all_entered"] for d in divisions),
+        }
+
+    return {
+        "grouped_games": grouped,
+        "today": today,
     }

--- a/leagues/tests.py
+++ b/leagues/tests.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from django.test import TestCase
 from django.test.client import Client
 from django.test.utils import override_settings
+from django.utils.http import urlencode
 
 from leagues.forms import MatchUpForm
 from leagues.models import Division, MatchUp, Player, Season, Team, Week
@@ -1285,6 +1286,337 @@ class StatInlineMatchupQuerysetTest(TestCase):
     def test_matchup_queryset_is_empty_when_no_object_id(self):
         field = self._make_inline(object_id=None)
         self.assertEqual(field.queryset.count(), 0)
+
+
+class ScheduleManagerViewTest(TestCase):
+    """Tests for the schedule manager custom admin view."""
+
+    def setUp(self):
+        self.client = Client()
+        self.admin_user = User.objects.create_superuser(
+            username="admin", email="admin@test.com", password="adminpass123"
+        )
+        self.client.login(username="admin", password="adminpass123")
+        self.season = Season.objects.create(
+            year=datetime.datetime.now().year, season_type=1, is_current_season=True
+        )
+        self.division1 = Division.objects.create(division=1)
+        self.division2 = Division.objects.create(division=2)
+        self.tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+        self.week1 = Week.objects.create(
+            division=self.division1, season=self.season, date=self.tomorrow
+        )
+        self.week2 = Week.objects.create(
+            division=self.division2, season=self.season, date=self.tomorrow
+        )
+        self.team1 = Team.objects.create(
+            team_name="A",
+            team_color="red",
+            season=self.season,
+            division=self.division1,
+            is_active=True,
+        )
+        self.team2 = Team.objects.create(
+            team_name="B",
+            team_color="blue",
+            season=self.season,
+            division=self.division1,
+            is_active=True,
+        )
+        self.team3 = Team.objects.create(
+            team_name="C",
+            team_color="green",
+            season=self.season,
+            division=self.division2,
+            is_active=True,
+        )
+        self.team4 = Team.objects.create(
+            team_name="D",
+            team_color="white",
+            season=self.season,
+            division=self.division2,
+            is_active=True,
+        )
+        self.matchup1 = MatchUp.objects.create(
+            week=self.week1,
+            time=datetime.time(18, 0),
+            awayteam=self.team1,
+            hometeam=self.team2,
+        )
+        self.matchup2 = MatchUp.objects.create(
+            week=self.week2,
+            time=datetime.time(19, 0),
+            awayteam=self.team3,
+            hometeam=self.team4,
+        )
+
+    def _url(self, **params):
+        base = reverse("admin:leagues_matchup_schedule_manager")
+        return base + ("?" + urlencode(params) if params else "")
+
+    def test_get_no_filters_shows_prompt(self):
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Select a filter above")
+        self.assertFalse(response.context["has_results"])
+
+    def test_get_division_filter_shows_only_that_division(self):
+        response = self.client.get(self._url(division_id=self.division1.pk))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context["has_results"])
+        dates = response.context["matchups_by_date"]
+        games = [g for gs in dates.values() for g in gs]
+        pks = [g.pk for g in games]
+        self.assertIn(self.matchup1.pk, pks)
+        self.assertNotIn(self.matchup2.pk, pks)
+
+    def test_get_date_filter_shows_all_divisions_on_that_date(self):
+        response = self.client.get(
+            self._url(filter_date=self.tomorrow.strftime("%Y-%m-%d"))
+        )
+        self.assertEqual(response.status_code, 200)
+        dates = response.context["matchups_by_date"]
+        games = [g for gs in dates.values() for g in gs]
+        pks = [g.pk for g in games]
+        self.assertIn(self.matchup1.pk, pks)
+        self.assertIn(self.matchup2.pk, pks)
+
+    def test_get_both_filters_narrows_correctly(self):
+        response = self.client.get(
+            self._url(
+                division_id=self.division1.pk,
+                filter_date=self.tomorrow.strftime("%Y-%m-%d"),
+            )
+        )
+        dates = response.context["matchups_by_date"]
+        games = [g for gs in dates.values() for g in gs]
+        pks = [g.pk for g in games]
+        self.assertIn(self.matchup1.pk, pks)
+        self.assertNotIn(self.matchup2.pk, pks)
+
+    def test_past_games_excluded(self):
+        past_week = Week.objects.create(
+            division=self.division1,
+            season=self.season,
+            date=datetime.date.today() - datetime.timedelta(days=1),
+        )
+        past_game = MatchUp.objects.create(
+            week=past_week,
+            time=datetime.time(18, 0),
+            awayteam=self.team1,
+            hometeam=self.team2,
+        )
+        response = self.client.get(self._url(division_id=self.division1.pk))
+        dates = response.context["matchups_by_date"]
+        all_pks = [g.pk for gs in dates.values() for g in gs]
+        self.assertNotIn(past_game.pk, all_pks)
+
+    def test_cancelled_games_excluded(self):
+        cancelled = MatchUp.objects.create(
+            week=self.week1,
+            time=datetime.time(20, 0),
+            awayteam=self.team1,
+            hometeam=self.team2,
+            is_cancelled=True,
+        )
+        response = self.client.get(self._url(division_id=self.division1.pk))
+        dates = response.context["matchups_by_date"]
+        all_pks = [g.pk for gs in dates.values() for g in gs]
+        self.assertNotIn(cancelled.pk, all_pks)
+
+    def test_post_updates_time(self):
+        url = reverse("admin:leagues_matchup_schedule_manager")
+        data = {
+            "_save": "1",
+            "division_id": str(self.division1.pk),
+            "filter_date": "",
+            "matchup_pks": str(self.matchup1.pk),
+            f"m_{self.matchup1.pk}_date": self.tomorrow.strftime("%Y-%m-%d"),
+            f"m_{self.matchup1.pk}_time": "20:00",
+        }
+        self.client.post(url, data)
+        self.matchup1.refresh_from_db()
+        self.assertEqual(self.matchup1.time, datetime.time(20, 0))
+
+    def test_post_updates_date_and_creates_new_week(self):
+        new_date = self.tomorrow + datetime.timedelta(days=7)
+        url = reverse("admin:leagues_matchup_schedule_manager")
+        data = {
+            "_save": "1",
+            "division_id": str(self.division1.pk),
+            "filter_date": "",
+            "matchup_pks": str(self.matchup1.pk),
+            f"m_{self.matchup1.pk}_date": new_date.strftime("%Y-%m-%d"),
+            f"m_{self.matchup1.pk}_time": self.matchup1.time.strftime("%H:%M"),
+        }
+        self.client.post(url, data)
+        self.matchup1.refresh_from_db()
+        self.assertEqual(self.matchup1.week.date, new_date)
+        self.assertTrue(
+            Week.objects.filter(
+                division=self.division1, season=self.season, date=new_date
+            ).exists()
+        )
+
+    def test_post_reuses_existing_week_when_date_matches(self):
+        new_date = self.tomorrow + datetime.timedelta(days=7)
+        existing_week = Week.objects.create(
+            division=self.division1, season=self.season, date=new_date
+        )
+        url = reverse("admin:leagues_matchup_schedule_manager")
+        data = {
+            "_save": "1",
+            "division_id": "",
+            "filter_date": "",
+            "matchup_pks": str(self.matchup1.pk),
+            f"m_{self.matchup1.pk}_date": new_date.strftime("%Y-%m-%d"),
+            f"m_{self.matchup1.pk}_time": self.matchup1.time.strftime("%H:%M"),
+        }
+        self.client.post(url, data)
+        self.matchup1.refresh_from_db()
+        self.assertEqual(self.matchup1.week_id, existing_week.pk)
+        # No duplicate week created
+        self.assertEqual(
+            Week.objects.filter(
+                division=self.division1, season=self.season, date=new_date
+            ).count(),
+            1,
+        )
+
+    def test_post_no_changes_shows_info_message(self):
+        url = reverse("admin:leagues_matchup_schedule_manager")
+        data = {
+            "_save": "1",
+            "division_id": "",
+            "filter_date": "",
+            "matchup_pks": str(self.matchup1.pk),
+            f"m_{self.matchup1.pk}_date": self.tomorrow.strftime("%Y-%m-%d"),
+            f"m_{self.matchup1.pk}_time": self.matchup1.time.strftime("%H:%M"),
+        }
+        response = self.client.post(url, data, follow=True)
+        messages_list = list(response.context["messages"])
+        self.assertTrue(any("No changes" in str(m) for m in messages_list))
+
+    def test_post_redirects_with_filters_preserved(self):
+        url = reverse("admin:leagues_matchup_schedule_manager")
+        data = {
+            "_save": "1",
+            "division_id": str(self.division1.pk),
+            "filter_date": self.tomorrow.strftime("%Y-%m-%d"),
+            "matchup_pks": "",
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(f"division_id={self.division1.pk}", response["Location"])
+        self.assertIn(self.tomorrow.strftime("%Y-%m-%d"), response["Location"])
+
+    def test_post_adds_new_matchup(self):
+        new_date = self.tomorrow + datetime.timedelta(days=14)
+        url = reverse("admin:leagues_matchup_schedule_manager")
+        data = {
+            "_save": "1",
+            "division_id": str(self.division1.pk),
+            "filter_date": "",
+            "matchup_pks": "",
+            "new_row_count": "1",
+            "new_0_date": new_date.strftime("%Y-%m-%d"),
+            "new_0_time": "18:00",
+            "new_0_away": str(self.team1.pk),
+            "new_0_home": str(self.team2.pk),
+            "new_0_division_id": str(self.division1.pk),
+        }
+        response = self.client.post(url, data, follow=True)
+        self.assertTrue(
+            MatchUp.objects.filter(
+                awayteam=self.team1,
+                hometeam=self.team2,
+                week__date=new_date,
+                time=datetime.time(18, 0),
+            ).exists()
+        )
+        messages_list = list(response.context["messages"])
+        self.assertTrue(any("added" in str(m) for m in messages_list))
+
+    def test_post_adds_and_updates_in_same_request(self):
+        new_date = self.tomorrow + datetime.timedelta(days=14)
+        url = reverse("admin:leagues_matchup_schedule_manager")
+        data = {
+            "_save": "1",
+            "division_id": "",
+            "filter_date": "",
+            "matchup_pks": str(self.matchup1.pk),
+            f"m_{self.matchup1.pk}_date": self.tomorrow.strftime("%Y-%m-%d"),
+            f"m_{self.matchup1.pk}_time": "20:00",  # changed
+            "new_row_count": "1",
+            "new_0_date": new_date.strftime("%Y-%m-%d"),
+            "new_0_time": "19:00",
+            "new_0_away": str(self.team1.pk),
+            "new_0_home": str(self.team2.pk),
+            "new_0_division_id": str(self.division1.pk),
+        }
+        response = self.client.post(url, data, follow=True)
+        self.matchup1.refresh_from_db()
+        self.assertEqual(self.matchup1.time, datetime.time(20, 0))
+        self.assertTrue(MatchUp.objects.filter(week__date=new_date).exists())
+        messages_list = list(response.context["messages"])
+        msg_text = " ".join(str(m) for m in messages_list)
+        self.assertIn("added", msg_text)
+        self.assertIn("updated", msg_text)
+
+    def test_post_add_skips_incomplete_rows(self):
+        url = reverse("admin:leagues_matchup_schedule_manager")
+        initial_count = MatchUp.objects.count()
+        data = {
+            "_save": "1",
+            "division_id": "",
+            "filter_date": "",
+            "matchup_pks": "",
+            "new_row_count": "1",
+            "new_0_date": self.tomorrow.strftime("%Y-%m-%d"),
+            "new_0_time": "18:00",
+            # missing away/home/division — should be skipped
+        }
+        self.client.post(url, data)
+        self.assertEqual(MatchUp.objects.count(), initial_count)
+
+    def test_post_add_creates_week_if_needed(self):
+        new_date = self.tomorrow + datetime.timedelta(days=21)
+        self.assertFalse(
+            Week.objects.filter(division=self.division1, date=new_date).exists()
+        )
+        url = reverse("admin:leagues_matchup_schedule_manager")
+        data = {
+            "_save": "1",
+            "division_id": str(self.division1.pk),
+            "filter_date": "",
+            "matchup_pks": "",
+            "new_row_count": "1",
+            "new_0_date": new_date.strftime("%Y-%m-%d"),
+            "new_0_time": "18:00",
+            "new_0_away": str(self.team1.pk),
+            "new_0_home": str(self.team2.pk),
+            "new_0_division_id": str(self.division1.pk),
+        }
+        self.client.post(url, data)
+        self.assertTrue(
+            Week.objects.filter(division=self.division1, date=new_date).exists()
+        )
+
+    def test_get_includes_teams_by_division_json(self):
+        import json
+
+        response = self.client.get(self._url(division_id=self.division1.pk))
+        self.assertIn("teams_by_division_json", response.context)
+        teams_map = json.loads(response.context["teams_by_division_json"])
+        div_teams = teams_map.get(str(self.division1.pk), [])
+        team_ids = [t["id"] for t in div_teams]
+        self.assertIn(self.team1.pk, team_ids)
+        self.assertIn(self.team2.pk, team_ids)
+
+    def test_requires_login(self):
+        self.client.logout()
+        response = self.client.get(self._url(division_id=self.division1.pk))
+        self.assertNotEqual(response.status_code, 200)
 
 
 class MatchUpSaveRedirectTest(TestCase):

--- a/leagues/tests.py
+++ b/leagues/tests.py
@@ -1285,3 +1285,346 @@ class StatInlineMatchupQuerysetTest(TestCase):
     def test_matchup_queryset_is_empty_when_no_object_id(self):
         field = self._make_inline(object_id=None)
         self.assertEqual(field.queryset.count(), 0)
+
+
+class MatchUpSaveRedirectTest(TestCase):
+    """Tests for MatchUpAdmin save button behaviour."""
+
+    def setUp(self):
+        self.client = Client()
+        self.admin_user = User.objects.create_superuser(
+            username="admin", email="admin@test.com", password="adminpass123"
+        )
+        self.client.login(username="admin", password="adminpass123")
+        self.season = Season.objects.create(
+            year=datetime.datetime.now().year, season_type=1, is_current_season=True
+        )
+        self.division = Division.objects.create(division=1)
+        self.week = Week.objects.create(
+            division=self.division,
+            season=self.season,
+            date=datetime.date.today(),
+        )
+        self.team1 = Team.objects.create(
+            team_name="Home",
+            team_color="red",
+            season=self.season,
+            division=self.division,
+            is_active=True,
+        )
+        self.team2 = Team.objects.create(
+            team_name="Away",
+            team_color="blue",
+            season=self.season,
+            division=self.division,
+            is_active=True,
+        )
+        self.matchup = MatchUp.objects.create(
+            week=self.week,
+            time=datetime.time(19, 0),
+            awayteam=self.team2,
+            hometeam=self.team1,
+        )
+
+    def _post_save(self, button="_save"):
+        url = reverse("admin:leagues_matchup_change", args=[self.matchup.pk])
+        data = {
+            button: "1",
+            "week": self.week.pk,
+            "time": "07:00 PM",
+            "awayteam": self.team2.pk,
+            "hometeam": self.team1.pk,
+            "away_goalie_status": 3,
+            "home_goalie_status": 3,
+            "stat_set-TOTAL_FORMS": "0",
+            "stat_set-INITIAL_FORMS": "0",
+            "stat_set-MIN_NUM_FORMS": "0",
+            "stat_set-MAX_NUM_FORMS": "1000",
+        }
+        return self.client.post(url, data)
+
+    def test_save_redirects_to_admin_home(self):
+        response = self._post_save("_save")
+        self.assertRedirects(response, reverse("admin:index"))
+
+    def test_save_and_continue_stays_on_change_page(self):
+        response = self._post_save("_continue")
+        expected = reverse("admin:leagues_matchup_change", args=[self.matchup.pk])
+        self.assertRedirects(response, expected)
+
+    def test_save_and_add_another_button_is_not_shown(self):
+        url = reverse("admin:leagues_matchup_change", args=[self.matchup.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "_addanother")
+
+
+class StatAutofillTeamTest(TestCase):
+    """Tests for change_view passing the player→team map used by stat_autofill_team.js."""
+
+    def setUp(self):
+        self.client = Client()
+        self.admin_user = User.objects.create_superuser(
+            username="admin", email="admin@test.com", password="adminpass123"
+        )
+        self.client.login(username="admin", password="adminpass123")
+        self.season = Season.objects.create(
+            year=datetime.datetime.now().year, season_type=1, is_current_season=True
+        )
+        self.division = Division.objects.create(division=1)
+        self.today = datetime.date.today()
+        self.week = Week.objects.create(
+            division=self.division, season=self.season, date=self.today
+        )
+        self.team1 = Team.objects.create(
+            team_name="Home Team",
+            team_color="red",
+            season=self.season,
+            division=self.division,
+            is_active=True,
+        )
+        self.team2 = Team.objects.create(
+            team_name="Away Team",
+            team_color="blue",
+            season=self.season,
+            division=self.division,
+            is_active=True,
+        )
+        self.matchup = MatchUp.objects.create(
+            week=self.week,
+            time=datetime.time(19, 0),
+            awayteam=self.team2,
+            hometeam=self.team1,
+        )
+        self.player1 = Player.objects.create(
+            first_name="Alice", last_name="Smith", is_active=True
+        )
+        self.player2 = Player.objects.create(
+            first_name="Bob", last_name="Jones", is_active=True
+        )
+        from leagues.models import Roster
+
+        Roster.objects.create(player=self.player1, team=self.team1, position1=3)
+        Roster.objects.create(player=self.player2, team=self.team2, position1=3)
+
+    def _change_url(self):
+        return reverse("admin:leagues_matchup_change", args=[self.matchup.pk])
+
+    def test_change_view_includes_player_team_map_json(self):
+        import json
+
+        response = self.client.get(self._change_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("player_team_map_json", response.context)
+        mapping = json.loads(response.context["player_team_map_json"])
+        self.assertEqual(mapping[str(self.player1.pk)], str(self.team1.pk))
+        self.assertEqual(mapping[str(self.player2.pk)], str(self.team2.pk))
+
+    def test_map_excludes_players_not_on_either_roster(self):
+        import json
+
+        other_player = Player.objects.create(
+            first_name="Other", last_name="Guy", is_active=True
+        )
+        response = self.client.get(self._change_url())
+        mapping = json.loads(response.context["player_team_map_json"])
+        self.assertNotIn(str(other_player.pk), mapping)
+
+    def test_map_contains_both_teams_players(self):
+        import json
+
+        response = self.client.get(self._change_url())
+        mapping = json.loads(response.context["player_team_map_json"])
+        self.assertIn(str(self.player1.pk), mapping)
+        self.assertIn(str(self.player2.pk), mapping)
+
+
+class StatsEntryWidgetTest(TestCase):
+    """Tests for the stats_entry_widget templatetag."""
+
+    def setUp(self):
+        self.season = Season.objects.create(
+            year=datetime.datetime.now().year, season_type=1, is_current_season=True
+        )
+        self.division = Division.objects.create(division=1)
+        self.today = datetime.date.today()
+        self.team1 = Team.objects.create(
+            team_name="Red Team",
+            team_color="red",
+            season=self.season,
+            division=self.division,
+            is_active=True,
+        )
+        self.team2 = Team.objects.create(
+            team_name="Blue Team",
+            team_color="blue",
+            season=self.season,
+            division=self.division,
+            is_active=True,
+        )
+        self.player = Player.objects.create(
+            first_name="Test",
+            last_name="Player",
+            is_active=True,
+        )
+
+    def _week(self, delta=0, cancelled=False):
+        return Week.objects.create(
+            division=self.division,
+            season=self.season,
+            date=self.today - datetime.timedelta(days=delta),
+            is_cancelled=cancelled,
+        )
+
+    def _matchup(self, week, cancelled=False):
+        return MatchUp.objects.create(
+            week=week,
+            time=datetime.time(19, 0),
+            awayteam=self.team1,
+            hometeam=self.team2,
+            is_cancelled=cancelled,
+        )
+
+    def _call_widget(self):
+        from leagues.templatetags.admin_quick_cancel import stats_entry_widget
+
+        return stats_entry_widget()
+
+    def test_recent_game_with_no_stats_appears_with_zero_count(self):
+        week = self._week(delta=1)
+        game = self._matchup(week)
+        ctx = self._call_widget()
+        all_games = [
+            g
+            for info in ctx["grouped_games"].values()
+            for d in info["divisions"]
+            for g in d["games"]
+        ]
+        pks = [g.pk for g in all_games]
+        self.assertIn(game.pk, pks)
+        match = next(g for g in all_games if g.pk == game.pk)
+        self.assertEqual(match.stat_count, 0)
+
+    def test_game_with_stats_shows_correct_count(self):
+        from leagues.models import Stat
+
+        week = self._week(delta=1)
+        game = self._matchup(week)
+        Stat.objects.create(
+            player=self.player, team=self.team1, matchup=game, goals=1, assists=0
+        )
+        Stat.objects.create(
+            player=self.player, team=self.team2, matchup=game, goals=0, assists=1
+        )
+        ctx = self._call_widget()
+        all_games = [
+            g
+            for info in ctx["grouped_games"].values()
+            for d in info["divisions"]
+            for g in d["games"]
+        ]
+        match = next(g for g in all_games if g.pk == game.pk)
+        self.assertEqual(match.stat_count, 2)
+
+    def test_cancelled_matchup_excluded(self):
+        week = self._week(delta=1)
+        cancelled_game = self._matchup(week, cancelled=True)
+        ctx = self._call_widget()
+        all_pks = [
+            g.pk
+            for info in ctx["grouped_games"].values()
+            for d in info["divisions"]
+            for g in d["games"]
+        ]
+        self.assertNotIn(cancelled_game.pk, all_pks)
+
+    def test_cancelled_week_excluded(self):
+        week = self._week(delta=1, cancelled=True)
+        game = self._matchup(week)
+        ctx = self._call_widget()
+        all_pks = [
+            g.pk
+            for info in ctx["grouped_games"].values()
+            for d in info["divisions"]
+            for g in d["games"]
+        ]
+        self.assertNotIn(game.pk, all_pks)
+
+    def test_game_older_than_seven_days_excluded(self):
+        week = self._week(delta=8)
+        old_game = self._matchup(week)
+        ctx = self._call_widget()
+        all_pks = [
+            g.pk
+            for info in ctx["grouped_games"].values()
+            for d in info["divisions"]
+            for g in d["games"]
+        ]
+        self.assertNotIn(old_game.pk, all_pks)
+
+    def test_future_game_excluded(self):
+        future_week = Week.objects.create(
+            division=self.division,
+            season=self.season,
+            date=self.today + datetime.timedelta(days=1),
+        )
+        future_game = self._matchup(future_week)
+        ctx = self._call_widget()
+        all_pks = [
+            g.pk
+            for info in ctx["grouped_games"].values()
+            for d in info["divisions"]
+            for g in d["games"]
+        ]
+        self.assertNotIn(future_game.pk, all_pks)
+
+    def test_all_entered_flag_true_when_all_games_have_stats(self):
+        from leagues.models import Stat
+
+        week = self._week(delta=1)
+        game = self._matchup(week)
+        Stat.objects.create(player=self.player, team=self.team1, matchup=game, goals=1)
+        ctx = self._call_widget()
+        date_info = ctx["grouped_games"][self.today - datetime.timedelta(days=1)]
+        self.assertTrue(date_info["divisions"][0]["all_entered"])
+
+    def test_any_missing_flag_true_when_a_game_lacks_stats(self):
+        week = self._week(delta=1)
+        self._matchup(week)
+        ctx = self._call_widget()
+        date_info = ctx["grouped_games"][self.today - datetime.timedelta(days=1)]
+        self.assertTrue(date_info["divisions"][0]["any_missing"])
+
+    def test_dates_ordered_most_recent_first(self):
+        week_yesterday = self._week(delta=1)
+        week_two_days_ago = self._week(delta=2)
+        self._matchup(week_yesterday)
+        self._matchup(week_two_days_ago)
+        ctx = self._call_widget()
+        dates = list(ctx["grouped_games"].keys())
+        self.assertGreater(dates[0], dates[1])
+
+    def test_games_grouped_by_date(self):
+        week_yesterday = self._week(delta=1)
+        week_two_days_ago = self._week(delta=2)
+        game1 = self._matchup(week_yesterday)
+        game2 = self._matchup(week_two_days_ago)
+        ctx = self._call_widget()
+        yesterday = self.today - datetime.timedelta(days=1)
+        two_days_ago = self.today - datetime.timedelta(days=2)
+        self.assertIn(yesterday, ctx["grouped_games"])
+        self.assertIn(two_days_ago, ctx["grouped_games"])
+        yesterday_pks = [
+            g.pk
+            for d in ctx["grouped_games"][yesterday]["divisions"]
+            for g in d["games"]
+        ]
+        two_days_ago_pks = [
+            g.pk
+            for d in ctx["grouped_games"][two_days_ago]["divisions"]
+            for g in d["games"]
+        ]
+        self.assertIn(game1.pk, yesterday_pks)
+        self.assertNotIn(game2.pk, yesterday_pks)
+        self.assertIn(game2.pk, two_days_ago_pks)
+        self.assertNotIn(game1.pk, two_days_ago_pks)

--- a/static/admin/js/stat_autofill_team.js
+++ b/static/admin/js/stat_autofill_team.js
@@ -1,0 +1,27 @@
+(function () {
+    'use strict';
+
+    var playerTeamMap = (typeof statPlayerTeamMap !== 'undefined') ? statPlayerTeamMap : {};
+
+    function autofillTeam(playerSelect) {
+        var match = playerSelect.name.match(/^stat_set-(\d+)-player$/);
+        if (!match) return;
+        var idx = match[1];
+        var teamSelect = document.querySelector('select[name="stat_set-' + idx + '-team"]');
+        if (!teamSelect) return;
+        var playerId = playerSelect.value;
+        if (playerId && playerTeamMap[playerId]) {
+            teamSelect.value = playerTeamMap[playerId];
+        }
+    }
+
+    // Event delegation: handles both existing rows and rows added via "Add another Stat".
+    document.addEventListener('change', function (e) {
+        if (
+            e.target.tagName === 'SELECT' &&
+            /^stat_set-\d+-player$/.test(e.target.name)
+        ) {
+            autofillTeam(e.target);
+        }
+    });
+})();

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n static admin_quick_cancel %}
+{% load i18n static admin_quick_cancel admin_urls %}
 
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" href="{% static "admin/css/dashboard.css" %}">{% endblock %}
 
@@ -17,6 +17,21 @@
   {% quick_cancel_widget %}
   {% endif %}
   {% stats_entry_widget %}
+
+  <div class="module" style="margin-bottom:20px;">
+    <h2>Staff Tools</h2>
+    <div style="padding:10px 12px;">
+      <a href="{% url 'admin:leagues_matchup_schedule_manager' %}"
+         style="display:inline-block;padding:8px 16px;background:#417690;color:#fff;
+                font-size:13px;font-weight:600;border-radius:4px;text-decoration:none;">
+        Manage Schedule
+      </a>
+      <span style="margin-left:10px;font-size:12px;color:#888;">
+        Update game dates &amp; times by division or date
+      </span>
+    </div>
+  </div>
+
   {% include "admin/app_list.html" with app_list=app_list show_changelinks=True %}
 </div>
 {% endblock %}

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -16,6 +16,7 @@
   {% if perms.leagues.can_quick_cancel_games %}
   {% quick_cancel_widget %}
   {% endif %}
+  {% stats_entry_widget %}
   {% include "admin/app_list.html" with app_list=app_list show_changelinks=True %}
 </div>
 {% endblock %}

--- a/templates/admin/leagues/matchup/change_form.html
+++ b/templates/admin/leagues/matchup/change_form.html
@@ -1,0 +1,47 @@
+{% extends "admin/change_form.html" %}
+{% block extrahead %}
+{% if player_team_map_json %}
+<script>var statPlayerTeamMap = {{ player_team_map_json|safe }};</script>
+{% endif %}
+{{ block.super }}
+{% endblock %}
+
+{% block submit_buttons_bottom %}
+<style>
+  .matchup-submit-row { display: flex; gap: 12px; flex-wrap: wrap; padding: 12px 0; }
+  .matchup-save-btn {
+    padding: 9px 16px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 1;
+  }
+  .matchup-save-btn.primary { background: #417690; color: #fff; }
+  .matchup-save-btn.primary:hover { background: #2c5f73; }
+  .matchup-save-btn.secondary { background: #f0f0f0; color: #333; border: 1px solid #ccc; }
+  .matchup-save-btn.secondary:hover { background: #e0e0e0; }
+  .matchup-delete-link {
+    margin-left: auto;
+    align-self: center;
+    color: #ba2121;
+    font-size: 13px;
+  }
+  @media (max-width: 600px) {
+    .matchup-save-btn { width: 100%; }
+    .matchup-delete-link { margin-left: 0; }
+  }
+</style>
+<div class="submit-row matchup-submit-row">
+  <button type="submit" name="_save" class="matchup-save-btn primary" title="Returns to home">Save</button>
+  {% if show_save_and_continue %}
+  <button type="submit" name="_continue" class="matchup-save-btn secondary" title="Stays on this game">Save and continue editing</button>
+  {% endif %}
+  {% if show_delete_link and original %}
+  {% load admin_urls %}
+  {% url opts|admin_urlname:'delete' original.pk|admin_urlquote as delete_url %}
+  <a href="{{ delete_url }}" class="matchup-delete-link deletelink">Delete</a>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/admin/leagues/matchup/schedule_manager.html
+++ b/templates/admin/leagues/matchup/schedule_manager.html
@@ -1,0 +1,428 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}Manage Schedule — {{ site_title }}{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">Home</a>
+  &rsaquo; Manage Schedule
+</div>
+{% endblock %}
+
+{% block content %}
+<style>
+  /* ---- Filter bar ---- */
+  .sm-filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 12px;
+    padding: 14px 16px;
+    background: #f8f8f8;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    margin-bottom: 20px;
+  }
+  .sm-filter-group { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+  .sm-filter-group label {
+    font-size: 11px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: .05em; color: #666;
+  }
+  .sm-filter-group select,
+  .sm-filter-group input[type="date"] {
+    font-size: 13px; padding: 6px 8px; border: 1px solid #ccc;
+    border-radius: 3px; background: #fff; min-width: 180px;
+  }
+  .sm-filter-actions { display: flex; gap: 8px; align-items: flex-end; padding-bottom: 1px; }
+
+  /* ---- Buttons ---- */
+  .sm-btn {
+    font-size: 13px; font-weight: 600; padding: 7px 14px; border-radius: 3px;
+    border: none; cursor: pointer; text-decoration: none; white-space: nowrap;
+    display: inline-block; line-height: 1.4;
+  }
+  .sm-btn-primary   { background: #417690; color: #fff; }
+  .sm-btn-primary:hover { background: #2c5f73; color: #fff; }
+  .sm-btn-secondary { background: #f0f0f0; color: #333; border: 1px solid #ccc; }
+  .sm-btn-secondary:hover { background: #e0e0e0; }
+  .sm-btn-add       { background: #2e7d32; color: #fff; font-size: 12px; padding: 6px 12px; }
+  .sm-btn-add:hover { background: #1b5e20; }
+
+  /* ---- Active filter chips ---- */
+  .sm-active-filters {
+    display: flex; align-items: center; gap: 8px;
+    margin-bottom: 12px; font-size: 13px; color: #555;
+  }
+  .sm-filter-chip {
+    background: #dbe8f0; color: #1a4a5c; font-weight: 600;
+    padding: 3px 9px; border-radius: 12px; font-size: 12px;
+  }
+
+  /* ---- Shared table styles ---- */
+  .sm-table-wrap { overflow-x: auto; }
+  .sm-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  .sm-table th {
+    background: #417690; color: #fff; text-align: left;
+    padding: 8px 12px; font-size: 11px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .05em; white-space: nowrap;
+  }
+  .sm-table td { padding: 7px 12px; border-bottom: 1px solid #f0f0f0; vertical-align: middle; }
+  .sm-table tr:hover td { background: #f9f9f9; }
+
+  .sm-date-row td {
+    background: #f5f5f5; font-size: 12px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .05em; color: #555; padding: 5px 12px;
+  }
+  .sm-date-row:hover td { background: #f0f0f0; }
+  .sm-today-chip {
+    background: #417690; color: #fff; font-size: 10px; font-weight: 700;
+    padding: 1px 6px; border-radius: 3px; margin-left: 6px;
+    vertical-align: middle; letter-spacing: .06em;
+  }
+
+  .sm-input-date, .sm-input-time, .sm-select {
+    font-size: 13px; padding: 5px 7px; border: 1px solid #ccc;
+    border-radius: 3px; background: #fff;
+  }
+  .sm-input-date  { width: 140px; }
+  .sm-input-time  { width: 110px; }
+  .sm-select      { min-width: 140px; }
+  .sm-input-date:focus, .sm-input-time:focus, .sm-select:focus {
+    border-color: #417690; outline: none;
+    box-shadow: 0 0 0 2px rgba(65,118,144,.2);
+  }
+
+  /* Highlight edited rows */
+  .sm-row-changed td { background: #fffbeb !important; }
+  .sm-row-changed .sm-input-date,
+  .sm-row-changed .sm-input-time { border-color: #e6a817; }
+
+  .sm-team       { font-weight: 500; }
+  .sm-division-tag { font-size: 11px; color: #888; white-space: nowrap; }
+
+  /* ---- Add-rows section ---- */
+  .sm-add-section {
+    margin-top: 24px; border: 1px solid #ddd; border-radius: 4px; overflow: hidden;
+  }
+  .sm-add-header {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 10px 14px; background: #f0f7f0; border-bottom: 1px solid #ddd;
+  }
+  .sm-add-header h3 { margin: 0; font-size: 13px; font-weight: 700; color: #2e7d32; }
+  .sm-add-table { border: none; }
+  .sm-add-table th { background: #4a7c59; }
+  .sm-add-row td { background: #fafff9; }
+  .sm-add-row:hover td { background: #f0faf0 !important; }
+
+  .sm-remove-btn {
+    font-size: 15px; line-height: 1; padding: 2px 7px; border: 1px solid #ccc;
+    border-radius: 3px; background: #f8f8f8; color: #666; cursor: pointer;
+  }
+  .sm-remove-btn:hover { background: #fce4e4; border-color: #e57373; color: #b71c1c; }
+
+  .sm-add-hint {
+    padding: 12px 16px; color: #888; font-size: 12px; font-style: italic;
+  }
+
+  /* ---- Save bar ---- */
+  .sm-save-bar {
+    display: flex; align-items: center; gap: 16px;
+    padding: 14px 0 4px; border-top: 1px solid #eee; margin-top: 8px;
+  }
+  .sm-change-count { font-size: 12px; color: #888; }
+
+  /* ---- Empty / prompt states ---- */
+  .sm-empty {
+    padding: 32px 16px; text-align: center; color: #888; font-size: 14px;
+    border: 1px dashed #ddd; border-radius: 4px;
+  }
+  .sm-empty strong { display: block; font-size: 15px; margin-bottom: 6px; color: #555; }
+
+  @media (max-width: 767px) {
+    .sm-filter-bar { flex-direction: column; align-items: stretch; }
+    .sm-filter-group select,
+    .sm-filter-group input[type="date"] { min-width: 0; width: 100%; }
+    .sm-input-date  { width: 120px; }
+    .sm-input-time  { width: 95px; }
+    .sm-select      { min-width: 110px; }
+    /* hide division col on mobile when not needed */
+    .sm-table .sm-col-division { display: none; }
+  }
+</style>
+
+<div id="content-main">
+
+  {# ---- Filter bar ---- #}
+  <form method="get" class="sm-filter-bar">
+    <div class="sm-filter-group">
+      <label for="sm-division">Division</label>
+      <select name="division_id" id="sm-division">
+        <option value="">All Divisions</option>
+        {% for div in all_divisions %}
+        <option value="{{ div.pk }}"{% if div.pk|stringformat:"s" == division_id %} selected{% endif %}>{{ div }}</option>
+        {% endfor %}
+      </select>
+    </div>
+
+    <div class="sm-filter-group">
+      <label for="sm-date">Date</label>
+      <input type="date" name="filter_date" id="sm-date" value="{{ filter_date }}">
+    </div>
+
+    <div class="sm-filter-actions">
+      <button type="submit" class="sm-btn sm-btn-primary">Show Games</button>
+      {% if has_filters %}
+      <a href="{% url 'admin:leagues_matchup_schedule_manager' %}" class="sm-btn sm-btn-secondary">Clear</a>
+      {% endif %}
+    </div>
+  </form>
+
+  {# ---- Active filter summary ---- #}
+  {% if has_filters %}
+  <div class="sm-active-filters">
+    Showing:
+    {% if division_id %}
+      {% for div in all_divisions %}{% if div.pk|stringformat:"s" == division_id %}<span class="sm-filter-chip">{{ div }}</span>{% endif %}{% endfor %}
+    {% else %}
+      <span class="sm-filter-chip">All Divisions</span>
+    {% endif %}
+    {% if filter_date %}
+      <span class="sm-filter-chip">{{ filter_date|date:"l, F j" }}</span>
+    {% else %}
+      <span class="sm-filter-chip">All Upcoming Dates</span>
+    {% endif %}
+  </div>
+  {% endif %}
+
+  {# ================================================================ #}
+  {# Main form — wraps both the edit table and the add-rows section   #}
+  {# ================================================================ #}
+  {% if not has_filters %}
+
+  <div class="sm-empty">
+    <strong>Select a filter above to load the schedule</strong>
+    Choose a division to see all its upcoming games, a date to see every game
+    that day, or both to narrow to a specific division on a specific date.
+  </div>
+
+  {% else %}
+
+  <form method="post" id="sm-save-form">
+    {% csrf_token %}
+    <input type="hidden" name="division_id" value="{{ division_id }}">
+    <input type="hidden" name="filter_date" value="{{ filter_date }}">
+    <input type="hidden" name="matchup_pks" value="{{ matchup_pks_str }}">
+    <input type="hidden" name="new_row_count" id="sm-new-row-count" value="0">
+
+    {# ---- Existing games table ---- #}
+    {% if has_results %}
+    <div class="sm-table-wrap">
+      <table class="sm-table">
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Time</th>
+            <th>Away Team</th>
+            <th>Home Team</th>
+            <th class="sm-col-division">Division</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for game_date, games in matchups_by_date.items %}
+          <tr class="sm-date-row">
+            <td colspan="5">
+              {{ game_date|date:"l, F j, Y" }}
+              {% if game_date == today %}<span class="sm-today-chip">TODAY</span>{% endif %}
+            </td>
+          </tr>
+          {% for game in games %}
+          <tr class="sm-game-row"
+              data-orig-date="{{ game.week.date|date:'Y-m-d' }}"
+              data-orig-time="{{ game.time|time:'H:i' }}">
+            <td>
+              <input type="date" name="m_{{ game.pk }}_date"
+                     value="{{ game.week.date|date:'Y-m-d' }}"
+                     class="sm-input-date sm-date-input">
+            </td>
+            <td>
+              <input type="time" name="m_{{ game.pk }}_time"
+                     value="{{ game.time|time:'H:i' }}"
+                     class="sm-input-time sm-time-input">
+            </td>
+            <td class="sm-team">{{ game.awayteam.team_name }}</td>
+            <td class="sm-team">{{ game.hometeam.team_name }}</td>
+            <td class="sm-division-tag sm-col-division">{{ game.week.division }}</td>
+          </tr>
+          {% endfor %}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% else %}
+    <div class="sm-empty" style="margin-bottom:0;border-radius:4px 4px 0 0;border-bottom:none;">
+      <strong>No upcoming games found for this filter</strong>
+      Use the section below to add the first games.
+    </div>
+    {% endif %}
+
+    {# ---- Add new games section ---- #}
+    <div class="sm-add-section">
+      <div class="sm-add-header">
+        <h3>Add New Games</h3>
+        <button type="button" id="sm-add-btn" class="sm-btn sm-btn-add">+ Add game</button>
+      </div>
+      <div class="sm-table-wrap">
+        <table class="sm-table sm-add-table">
+          <thead>
+            <tr>
+              {% if not division_id %}<th>Division</th>{% endif %}
+              <th>Date</th>
+              <th>Time</th>
+              <th>Away Team</th>
+              <th>Home Team</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody id="sm-add-tbody"></tbody>
+        </table>
+      </div>
+      <p class="sm-add-hint" id="sm-add-hint">Click "+ Add game" to add a new game to the schedule.</p>
+    </div>
+
+    {# ---- Save bar ---- #}
+    <div class="sm-save-bar">
+      <button type="submit" name="_save" class="sm-btn sm-btn-primary">Save All Changes</button>
+      <span class="sm-change-count" id="sm-change-count"></span>
+    </div>
+  </form>
+  {% endif %}
+
+</div>{# end content-main #}
+
+<script>
+(function () {
+  /* ------------------------------------------------------------------ */
+  /* Data from server                                                     */
+  /* ------------------------------------------------------------------ */
+  var smTeamsByDiv    = {{ teams_by_division_json|safe }};
+  var smDivisionNames = {{ division_names_json|safe }};
+  var smSingleDivId   = "{{ division_id }}";
+  var smDefaultDate   = "{{ filter_date }}";
+  var smRowCount      = 0;
+
+  /* ------------------------------------------------------------------ */
+  /* Helpers                                                              */
+  /* ------------------------------------------------------------------ */
+  function teamOptions(divId) {
+    var teams = (divId && smTeamsByDiv[String(divId)]) || [];
+    var html = '<option value="">— Select Team —</option>';
+    teams.forEach(function (t) {
+      html += '<option value="' + t.id + '">' + t.name + '</option>';
+    });
+    return html;
+  }
+
+  function refreshTeamSelects(idx, divId) {
+    var opts = teamOptions(divId);
+    var row = document.getElementById('sm-add-row-' + idx);
+    if (!row) return;
+    row.querySelector('[name="new_' + idx + '_away"]').innerHTML = opts;
+    row.querySelector('[name="new_' + idx + '_home"]').innerHTML = opts;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Add a new row                                                        */
+  /* ------------------------------------------------------------------ */
+  function addRow() {
+    var idx = smRowCount++;
+    document.getElementById('sm-new-row-count').value = smRowCount;
+
+    var tr = document.createElement('tr');
+    tr.className = 'sm-add-row';
+    tr.id = 'sm-add-row-' + idx;
+
+    var cells = '';
+
+    /* Division cell — only when no division filter is active */
+    if (!smSingleDivId) {
+      var divOpts = '<option value="">— Select Division —</option>';
+      Object.keys(smDivisionNames).sort().forEach(function (id) {
+        divOpts += '<option value="' + id + '">' + smDivisionNames[id] + '</option>';
+      });
+      cells += '<td><select name="new_' + idx + '_division_id" class="sm-select"'
+             + ' data-idx="' + idx + '" id="sm-div-sel-' + idx + '">'
+             + divOpts + '</select></td>';
+    } else {
+      cells += '<td style="display:none">'
+             + '<input type="hidden" name="new_' + idx + '_division_id" value="' + smSingleDivId + '">'
+             + '</td>';
+    }
+
+    var initialTeamOpts = teamOptions(smSingleDivId);
+
+    cells += '<td><input type="date"  name="new_' + idx + '_date"  value="' + smDefaultDate + '" class="sm-input-date" required></td>';
+    cells += '<td><input type="time"  name="new_' + idx + '_time"  class="sm-input-time" required></td>';
+    cells += '<td><select             name="new_' + idx + '_away"  class="sm-select" required>' + initialTeamOpts + '</select></td>';
+    cells += '<td><select             name="new_' + idx + '_home"  class="sm-select" required>' + initialTeamOpts + '</select></td>';
+    cells += '<td><button type="button" class="sm-remove-btn" data-idx="' + idx + '" title="Remove row">&times;</button></td>';
+
+    tr.innerHTML = cells;
+
+    /* Division change → refresh team dropdowns */
+    if (!smSingleDivId) {
+      tr.querySelector('#sm-div-sel-' + idx).addEventListener('change', function () {
+        refreshTeamSelects(this.dataset.idx, this.value);
+      });
+    }
+
+    /* Remove button */
+    tr.querySelector('.sm-remove-btn').addEventListener('click', function () {
+      tr.remove();
+      updateHint();
+    });
+
+    document.getElementById('sm-add-tbody').appendChild(tr);
+    updateHint();
+  }
+
+  function updateHint() {
+    var hint = document.getElementById('sm-add-hint');
+    if (!hint) return;
+    hint.style.display =
+      document.querySelectorAll('#sm-add-tbody .sm-add-row').length === 0 ? '' : 'none';
+  }
+
+  document.getElementById('sm-add-btn').addEventListener('click', addRow);
+
+  /* ------------------------------------------------------------------ */
+  /* Highlight edited existing rows + live change counter                */
+  /* ------------------------------------------------------------------ */
+  var existingRows = document.querySelectorAll('.sm-game-row');
+  var countEl = document.getElementById('sm-change-count');
+
+  function updateChangedState() {
+    var changed = 0;
+    existingRows.forEach(function (row) {
+      var isChanged =
+        row.querySelector('.sm-date-input').value !== row.dataset.origDate ||
+        row.querySelector('.sm-time-input').value !== row.dataset.origTime;
+      row.classList.toggle('sm-row-changed', isChanged);
+      if (isChanged) changed++;
+    });
+    if (countEl) {
+      countEl.textContent = changed > 0
+        ? changed + ' unsaved change' + (changed !== 1 ? 's' : '')
+        : '';
+    }
+  }
+
+  existingRows.forEach(function (row) {
+    row.querySelectorAll('input').forEach(function (input) {
+      input.addEventListener('change', updateChangedState);
+      input.addEventListener('input', updateChangedState);
+    });
+  });
+})();
+</script>
+{% endblock %}

--- a/templates/admin/stats_entry_widget.html
+++ b/templates/admin/stats_entry_widget.html
@@ -1,0 +1,179 @@
+<style>
+  .se-module { margin-bottom: 20px; }
+  .se-date-group { border-bottom: 1px solid #eee; }
+  .se-date-group:last-child { border-bottom: none; }
+  .se-date-heading {
+    font-size: 13px;
+    font-weight: bold;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 10px 12px 6px;
+    margin: 0;
+  }
+  .se-today-badge {
+    display: inline-block;
+    background: #417690;
+    color: #fff;
+    font-size: 11px;
+    font-weight: 700;
+    padding: 2px 7px;
+    border-radius: 3px;
+    margin-right: 6px;
+    letter-spacing: 0.06em;
+    vertical-align: middle;
+  }
+
+  /* Division rows */
+  details.se-division { border-top: 1px solid #f0f0f0; }
+  details.se-division:first-of-type { border-top: none; }
+  summary.se-division-summary {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    cursor: pointer;
+    list-style: none;
+    user-select: none;
+  }
+  summary.se-division-summary::-webkit-details-marker { display: none; }
+  .se-division-chevron {
+    font-size: 11px;
+    color: #999;
+    transition: transform 0.15s;
+    flex-shrink: 0;
+  }
+  details[open] .se-division-chevron { transform: rotate(90deg); }
+  .se-division-name {
+    font-size: 14px;
+    font-weight: 500;
+    flex: 1;
+    min-width: 0;
+  }
+  .se-status-badge {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 7px;
+    border-radius: 3px;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .se-status-done { background: #e8f5e9; color: #2e7d32; }
+  .se-status-pending { background: #fff3e0; color: #e65100; }
+
+  /* Game rows */
+  .se-games { padding: 2px 12px 10px 28px; }
+  .se-game-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 0;
+    border-top: 1px solid #f5f5f5;
+  }
+  .se-game-row:first-child { border-top: none; }
+  .se-game-time {
+    font-size: 12px;
+    font-weight: 600;
+    color: #555;
+    min-width: 60px;
+    flex-shrink: 0;
+  }
+  .se-game-matchup {
+    font-size: 13px;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .se-stat-count {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 7px;
+    border-radius: 3px;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .se-stat-count-zero { background: #fce4e4; color: #b71c1c; }
+  .se-stat-count-has { background: #e8f5e9; color: #2e7d32; }
+
+  /* Action button */
+  .se-btn {
+    font-size: 11px;
+    padding: 4px 9px;
+    cursor: pointer;
+    border-radius: 4px;
+    border: none;
+    font-weight: 600;
+    white-space: nowrap;
+    line-height: 1.3;
+    flex-shrink: 0;
+    text-decoration: none;
+    display: inline-block;
+  }
+  .se-btn-enter { background: #417690; color: #fff; }
+  .se-btn-enter:hover { background: #2c5f73; color: #fff; }
+  .se-btn-edit { background: #79aec8; color: #fff; }
+  .se-btn-edit:hover { background: #5e9ab8; color: #fff; }
+
+  .se-no-games {
+    padding: 10px 12px;
+    color: #888;
+    font-style: italic;
+    font-size: 13px;
+  }
+
+  @media (max-width: 600px) {
+    summary.se-division-summary { padding: 10px 12px; }
+    .se-btn { font-size: 12px; padding: 7px 10px; }
+    .se-games { padding-bottom: 12px; }
+  }
+</style>
+
+<div class="module se-module">
+  <h2>📋 Enter Stats</h2>
+  {% if grouped_games %}
+  {% for game_date, info in grouped_games.items %}
+  <div class="se-date-group">
+    <p class="se-date-heading">
+      {% if game_date == today %}<span class="se-today-badge">TODAY</span>{% endif %}
+      {{ game_date|date:"l, F j" }}
+    </p>
+
+    {% for div in info.divisions %}
+    <details class="se-division"{% if div.any_missing %} open{% endif %}>
+      <summary class="se-division-summary">
+        <span class="se-division-chevron">&#9658;</span>
+        <span class="se-division-name">{{ div.division }}</span>
+        {% if div.all_entered %}
+          <span class="se-status-badge se-status-done">All Entered</span>
+        {% else %}
+          <span class="se-status-badge se-status-pending">Stats Needed</span>
+        {% endif %}
+      </summary>
+
+      <div class="se-games">
+        {% for game in div.games %}
+        <div class="se-game-row">
+          <span class="se-game-time">{{ game.time|date:"g:i A" }}</span>
+          <span class="se-game-matchup">{{ game.awayteam.team_name }} vs {{ game.hometeam.team_name }}</span>
+          {% if game.stat_count == 0 %}
+            <span class="se-stat-count se-stat-count-zero">0 stats</span>
+            <a href="{% url 'admin:leagues_matchup_change' game.pk %}" class="se-btn se-btn-enter">Enter Stats</a>
+          {% else %}
+            <span class="se-stat-count se-stat-count-has">{{ game.stat_count }} stat{{ game.stat_count|pluralize }}</span>
+            <a href="{% url 'admin:leagues_matchup_change' game.pk %}" class="se-btn se-btn-edit">Edit</a>
+          {% endif %}
+        </div>
+        {% empty %}
+        <p style="color:#999;font-size:12px;margin:4px 0">No games scheduled.</p>
+        {% endfor %}
+      </div>
+    </details>
+    {% endfor %}
+  </div>
+  {% endfor %}
+  {% else %}
+  <div class="se-no-games">No completed games in the past week.</div>
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary

- Adds a **Schedule Manager** page (Staff Tools on admin home) for viewing, rescheduling, and adding upcoming matchups filtered by division and/or date — all in a single form submission
- Adds a **stats entry widget** on the admin home showing the past 7 days of games grouped by date/division with per-game stat counts and direct links to enter or edit stats
- Auto-populates the **team field** when a player is selected in the stats inline on the matchup change page
- Cleans up matchup save buttons: "Save" returns to admin home, "Save and continue editing" stays on the game, "Save and add another" removed

## Test plan

- [ ] Filter Schedule Manager by division — only that division's upcoming games appear
- [ ] Filter by date — all divisions on that date appear
- [ ] Edit a game time inline and save — time updates, redirects back with filters preserved
- [ ] Edit a game date — new Week is created (or existing one reused); matchup moves to new date
- [ ] Add a new game row, fill in date/time/away/home/division, save — game created, success message shows "N games added"
- [ ] Edit and add in the same submission — combined message shows both counts
- [ ] Stats entry widget: games from past 7 days with 0 stats show red badge + Enter Stats button
- [ ] Stats entry widget: games with stats show green count badge + Edit button
- [ ] Select a player in the stats inline — team field auto-populates
- [ ] "Save" on matchup change page → returns to admin home
- [ ] "Save and continue editing" → stays on the matchup

🤖 Generated with [Claude Code](https://claude.com/claude-code)