### PR TITLE
Fix broken division buttons on Hall of Fame page

### DIFF
--- a/core/tests/test_template_integrity.py
+++ b/core/tests/test_template_integrity.py
@@ -130,6 +130,40 @@ class HofRankingsPartialTest(TestCase):
         self.assertIn("No Offensive stats yet.", html)
 
 
+class HofDivisionButtonsTest(TestCase):
+    """
+    leagues/hof.html division pills used onclick="handleOption(\\'d1\\')" with
+    literal backslash-escaped quotes. Inside the double-quoted attribute those
+    backslashes are not an escape, so the browser parsed handleOption(\\'d1\\')
+    as invalid JS and every division button silently did nothing when clicked.
+    The handlers must use plain single quotes.
+    """
+
+    def _render(self):
+        empty = {"player_ranks": [], "section_name": "combined"}
+        return render_to_string(
+            "leagues/hof.html",
+            {
+                "all_ranks": [],
+                "d1_ranks": [],
+                "d2_ranks": [],
+                "draft_ranks": [],
+                "mona_ranks": [],
+                "monb_ranks": [],
+                "selected_gender": "all",
+                **empty,
+            },
+        )
+
+    def test_division_buttons_have_valid_onclick(self):
+        html = self._render()
+        # The broken form had a backslash before the quote.
+        self.assertNotIn("handleOption(\\'", html)
+        # Every division pill must call handleOption with a plain-quoted arg.
+        for name in ("combined", "d1", "d2", "draft", "mona", "monb"):
+            self.assertIn(f"handleOption('{name}')", html)
+
+
 class TemplateFixtureBase(TestCase):
     """Minimal season/team/matchup/stat fixture for full-page rendering."""
 

--- a/leagues/templates/leagues/hof.html
+++ b/leagues/templates/leagues/hof.html
@@ -16,12 +16,12 @@
                 </select>
             </div>
             <div class="pill-group">
-                <button type="button" id="combinedoptiondiv" class="pill-item activeoption" onclick="handleOption(\'combined\')">Combined</button>
-                <button type="button" id="d1optiondiv" class="pill-item" onclick="handleOption(\'d1\')">D1</button>
-                <button type="button" id="d2optiondiv" class="pill-item" onclick="handleOption(\'d2\')">D2</button>
-                <button type="button" id="draftoptiondiv" class="pill-item" onclick="handleOption(\'draft\')">Draft</button>
-                <button type="button" id="monaoptiondiv" class="pill-item" onclick="handleOption(\'mona\')">Mon-A</button>
-                <button type="button" id="monboptiondiv" class="pill-item" onclick="handleOption(\'monb\')">Mon-B</button>
+                <button type="button" id="combinedoptiondiv" class="pill-item activeoption" onclick="handleOption('combined')">Combined</button>
+                <button type="button" id="d1optiondiv" class="pill-item" onclick="handleOption('d1')">D1</button>
+                <button type="button" id="d2optiondiv" class="pill-item" onclick="handleOption('d2')">D2</button>
+                <button type="button" id="draftoptiondiv" class="pill-item" onclick="handleOption('draft')">Draft</button>
+                <button type="button" id="monaoptiondiv" class="pill-item" onclick="handleOption('mona')">Mon-A</button>
+                <button type="button" id="monboptiondiv" class="pill-item" onclick="handleOption('monb')">Mon-B</button>
             </div>
 
             <section id="combinedsection" class="stats show">


### PR DESCRIPTION
## Summary

The division switch buttons on the Hall of Fame / history page (`/hof/`) didn't work — clicking Combined, D1, D2, Draft, Mon-A, or Mon-B did nothing.

## Root cause

The division pill buttons in `leagues/templates/leagues/hof.html` had malformed `onclick` handlers:

```html
<button ... onclick="handleOption(\'d1\')">D1</button>
```

Because the attribute is wrapped in double quotes, the `\'` backslashes are **not** a valid escape. The browser parsed `handleOption(\'d1\')` as a JavaScript syntax error, so every click threw and no section ever switched.

## Fix

Use plain single quotes, which are valid inside a double-quoted attribute:

```html
<button ... onclick="handleOption('d1')">D1</button>
```

## Tests

Added `HofDivisionButtonsTest` to `core/tests/test_template_integrity.py` (following the existing template-regression convention). It renders `hof.html` and asserts the broken `handleOption(\'` form is absent and each pill calls `handleOption('<name>')` with a well-formed argument. The full `test_template_integrity` module (21 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cr6obsDvFNwCND18xAaon

---
_Generated by [Claude Code](https://claude.ai/code/session_017cr6obsDvFNwCND18xAaon)_