### PR TITLE
Standardize street/ball hockey terminology + add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,4 @@
 ## Checklist
 - [ ] Tests added/updated and the suite passes
 - [ ] Works on mobile (≤600px) and desktop
-- [ ] Street-hockey terminology (no "skater"/"ice hockey" language)
+- [ ] Correct terminology: street hockey / ball hockey (never "ice hockey" or "floor hockey"), and players/forwards/defense/goalies (never "skater")

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## What & why
+<!-- One or two sentences on what this changes and why. Link the issue if there is one. -->
+
+## Checklist
+- [ ] Tests added/updated and the suite passes
+- [ ] Works on mobile (≤600px) and desktop
+- [ ] Street-hockey terminology (no "skater"/"ice hockey" language)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,15 +127,16 @@ Every UI change must work well on both desktop and mobile devices. This is not o
 
 ---
 
-## Terminology — floor hockey, not ice hockey
+## Terminology — street hockey (a.k.a. ball hockey)
 
-DC Street Hockey is a **floor hockey** league. It plays just like ice hockey — same positions, same rules — except players run instead of skate, and a ball is used instead of a puck. Use the correct vocabulary everywhere: code, comments, templates, and test fixtures.
+DC Street Hockey is a **street hockey** league — also called **ball hockey**. It shares the same positions and rules as ice hockey, but it is neither ice hockey nor floor hockey: players run instead of skate, and a ball is used instead of a puck. Never call the sport "ice hockey" or "floor hockey". Use the correct vocabulary everywhere: code, comments, templates, and test fixtures.
 
 | Never use | Use instead |
 | --- | --- |
 | skater | player, or their specific position |
 | skating | running |
 | field player | player, non-goalie, or their specific position |
+| floor hockey / ice hockey | street hockey, or ball hockey |
 
 Acceptable position terms: **player** (generic), **center**, **wing**, **defense**, **goalie**, **forward** (center or wing). When the distinction matters, prefer the specific position.
 

--- a/core/tests/test_schedule_views.py
+++ b/core/tests/test_schedule_views.py
@@ -1770,7 +1770,7 @@ class MatchUpDetailViewTest(ScheduleTestBase):
         self.assertEqual(response.context["date_of_week"], self.past_date)
 
     def test_scoresheet_uses_hockey_periods_not_halves(self):
-        # Floor hockey has three periods, not two halves. The printed score
+        # Street hockey has three periods, not two halves. The printed score
         # grid must show 1st / 2nd / 3rd period columns.
         response = self.client.get(self.url)
         content = response.content.decode()

--- a/core/tests/test_terminology.py
+++ b/core/tests/test_terminology.py
@@ -1,0 +1,77 @@
+"""
+Guard test enforcing consistent sport terminology across the codebase.
+
+DC Street Hockey is street hockey (a.k.a. ball hockey) — never "ice hockey"
+or "floor hockey", and players are never "skaters". See the Terminology
+section of CLAUDE.md. This test scans the project's Python and template
+source so banned wording can't silently creep back in.
+"""
+
+import os
+import re
+
+from django.test import SimpleTestCase
+
+# Repo root: this file lives at <root>/core/tests/test_terminology.py
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+)
+
+# Words/phrases that must never appear in code or templates.
+FORBIDDEN = re.compile(
+    r"\b(skaters?|skating|floor[\s-]?hockey|ice[\s-]?hockey|field player)\b",
+    re.IGNORECASE,
+)
+
+# Only source we author and ship. (Docs like CLAUDE.md legitimately quote the
+# banned words to define them, so Markdown is intentionally excluded.)
+SCAN_EXTENSIONS = (".py", ".html")
+
+# Directories to skip entirely.
+EXCLUDE_DIRS = {
+    ".git",
+    "__pycache__",
+    "node_modules",
+    "venv",
+    "staticfiles",
+    # Applied migrations are historical records — a since-removed field there
+    # (SeasonSignup.position_preference) still carries a "Skater" label and
+    # must not be edited retroactively.
+    "migrations",
+}
+
+# This test file necessarily contains the banned words as patterns.
+EXCLUDE_FILES = {os.path.abspath(__file__)}
+
+
+def _iter_source_files():
+    for dirpath, dirnames, filenames in os.walk(REPO_ROOT):
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDE_DIRS]
+        for name in filenames:
+            if not name.endswith(SCAN_EXTENSIONS):
+                continue
+            path = os.path.join(dirpath, name)
+            if path in EXCLUDE_FILES:
+                continue
+            yield path
+
+
+class TerminologyGuardTest(SimpleTestCase):
+    """No banned ice/floor-hockey or 'skater' language in source."""
+
+    def test_no_forbidden_terms_in_source(self):
+        offenders = []
+        for path in _iter_source_files():
+            with open(path, encoding="utf-8", errors="ignore") as fh:
+                for lineno, line in enumerate(fh, start=1):
+                    match = FORBIDDEN.search(line)
+                    if match:
+                        rel = os.path.relpath(path, REPO_ROOT)
+                        offenders.append(f"{rel}:{lineno}: {match.group(0)!r}")
+
+        self.assertEqual(
+            offenders,
+            [],
+            "Banned sport terminology found — use street/ball hockey and "
+            "player/forward/defense/goalie instead:\n" + "\n".join(offenders),
+        )

--- a/core/tests/test_weather.py
+++ b/core/tests/test_weather.py
@@ -94,7 +94,7 @@ class ComputePlayabilityTest(TestCase):
         self.assertEqual(_compute_playability(None, "Sunny"), "good")
 
     def test_fog_is_good(self):
-        # Fog is not a cancellation condition for floor hockey
+        # Fog is not a cancellation condition for street hockey
         self.assertEqual(_compute_playability(0, "Dense Fog"), "good")
 
 


### PR DESCRIPTION
## What & why

Two related consistency changes:

1. **Terminology sweep.** DC Street Hockey is street hockey (a.k.a. ball hockey) — not ice hockey and not floor hockey — and players are never "skaters". This makes the language consistent everywhere:
   - Rewrites the `CLAUDE.md` terminology section to name the sport correctly and adds floor/ice hockey to the banned-terms table.
   - Fixes "floor hockey" comments in `test_weather.py` and `test_schedule_views.py`.
   - Adds `core/tests/test_terminology.py` — a guard test that scans all Python and template source for banned wording (skater/skating/floor hockey/ice hockey/field player) so it can't silently regress. Applied migrations are excluded since they're historical records (a since-removed field there still carries a "Skater" label).
2. **PR template.** Adds a minimal `.github/pull_request_template.md` with a "what & why" prompt and a short pre-merge checklist mapped to the project's core rules (tests, mobile+desktop, correct terminology).

Templates and live models were already clean — all user-facing copy says "DC Street Hockey" and positions are Center/Wing/Defense/Goalie.

## Checklist
- [x] Tests added/updated and the suite passes <!-- new guard test; full suite green (809 tests) -->
- [x] Works on mobile (≤600px) and desktop <!-- no UI change -->
- [x] Correct terminology: street hockey / ball hockey, players/forwards/defense/goalies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cr6obsDvFNwCND18xAaon