### PR TITLE
Make captain roster-email sign-off generic

### DIFF
--- a/leagues/templates/leagues/draft_board.html
+++ b/leagues/templates/leagues/draft_board.html
@@ -2521,7 +2521,7 @@ function emailMyTeam() {
         bodyLines.push('');
       }
     }
-    bodyLines.push('See you on the floor!');
+    bodyLines.push("Let's go!");
     const body = encodeURIComponent(bodyLines.join('\n'));
 
     const mailto = `mailto:${emails.join(',')}?subject=${subject}&body=${body}`;

--- a/leagues/test_draft.py
+++ b/leagues/test_draft.py
@@ -468,6 +468,16 @@ class BoardViewTests(DraftTestBase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_roster_email_signoff_is_generic(self):
+        # The captain roster-email sign-off should be a generic cheer, not a
+        # venue-specific "on the floor" line.
+        response = self.client.get(
+            reverse("draft_board_spectator", args=[self.session.pk])
+        )
+        content = response.content.decode()
+        self.assertIn("Let's go!", content)
+        self.assertNotIn("See you on the floor", content)
+
     def test_commissioner_view_renders(self):
         response = self.client.get(
             reverse(


### PR DESCRIPTION
## What & why

The auto-generated captain roster email (composed in `draft_board.html`) signed off with "See you on the floor!", which ties the message to a specific venue/surface. Change it to a generic cheer, "Let's go!".

## Checklist
- [x] Tests added/updated and the suite passes <!-- new regression test in BoardViewTests -->
- [x] Works on mobile (≤600px) and desktop <!-- email-body text only, no UI change -->
- [x] Correct terminology: street hockey / ball hockey, players/forwards/defense/goalies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cr6obsDvFNwCND18xAaon

---
_Generated by [Claude Code](https://claude.ai/code/session_017cr6obsDvFNwCND18xAaon)_