### PR TITLE
Serve static files compressed via WhiteNoise to cut bandwidth

### DIFF
--- a/dcstreethockey/settings/base.py
+++ b/dcstreethockey/settings/base.py
@@ -36,11 +36,10 @@ DEBUG = True
 if not DEBUG:
     # Tell Django to copy static assets into a path called `staticfiles` (this is specific to Render)
     STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
-    # Enable the WhiteNoise storage backend, which compresses static files to reduce disk use
-    # and renames the files with unique names for each version to support long-term caching
-    STATICFILES_STORAGE = (
-        "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
-    )
+    # Enable the WhiteNoise storage backend, which precompresses static files
+    # (gzip + brotli) to reduce outbound bandwidth and renames them with
+    # content-hashed names for long-term browser caching.
+    STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 ALLOWED_HOSTS = ["*"]
 

--- a/dcstreethockey/settings/production.py
+++ b/dcstreethockey/settings/production.py
@@ -9,5 +9,8 @@ SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
 SECURE_SSL_REDIRECT = True
 
-# Static files: content-hashed filenames enable long-term browser caching
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+# Static files: WhiteNoise's compressed manifest storage content-hashes
+# filenames for long-term browser caching AND precompresses assets to gzip +
+# brotli at collectstatic time, so CSS/JS are served compressed. This cuts
+# outbound bandwidth (now metered in 1GB increments on Render's Hobby plan).
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"

--- a/dcstreethockey/tests.py
+++ b/dcstreethockey/tests.py
@@ -1,5 +1,7 @@
+import importlib
+
 from django.core.cache import cache
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.urls import reverse
 
 from core.views import PlayerStatDetailView
@@ -97,3 +99,32 @@ class DraftSignupUrlContextProcessorTest(TestCase):
         DraftSession.objects.create(season=self.season, signups_open=False)
         ctx = draft_signup_url(self._make_request())
         self.assertIsNone(ctx["draft_signup_url"])
+
+
+class ProductionStaticStorageTest(SimpleTestCase):
+    """
+    Production must serve static files through WhiteNoise's compressed manifest
+    storage so CSS/JS ship gzip + brotli compressed. Serving them uncompressed
+    (plain ManifestStaticFilesStorage) needlessly inflates Render bandwidth,
+    which is now metered in 1GB increments. Guard both the production and the
+    shared not-DEBUG configuration against regressing to an uncompressed backend.
+    """
+
+    COMPRESSED = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+
+    def test_production_uses_compressed_whitenoise_storage(self):
+        production = importlib.import_module("dcstreethockey.settings.production")
+        self.assertEqual(production.STATICFILES_STORAGE, self.COMPRESSED)
+
+    def test_base_not_debug_block_uses_compressed_whitenoise_storage(self):
+        # The not-DEBUG branch of base.py (used by any non-debug deployment)
+        # must configure the same compressed backend.
+        import inspect
+
+        from dcstreethockey.settings import base
+
+        source = inspect.getsource(base)
+        self.assertIn(self.COMPRESSED, source)
+        self.assertNotIn(
+            "django.contrib.staticfiles.storage.ManifestStaticFilesStorage", source
+        )


### PR DESCRIPTION
## What & why

Production set `STATICFILES_STORAGE` to plain `ManifestStaticFilesStorage`, so CSS/JS were content-hashed for caching but served **uncompressed** — even though WhiteNoise middleware was active and `Brotli` was already in `requirements.txt`. Switching to WhiteNoise's `CompressedManifestStaticFilesStorage` makes `collectstatic` precompress assets to gzip + brotli.

This directly reduces Render **outbound bandwidth**, which now matters: the Hobby plan's updated pricing meters bandwidth in 1GB increments above a 5GB monthly allowance.

Verified with `collectstatic` under production settings:
- 564 `.gz` + 568 `.br` variants generated
- e.g. `admin/css/base.css` shrinks 21.3KB → 4.8KB (~78% smaller)

Also fixes the `base.py` not-DEBUG block (its comment claimed compression it wasn't actually doing).

## Checklist
- [x] Tests added/updated and the suite passes <!-- guard tests in ProductionStaticStorageTest; full suite 811 green; collectstatic verified -->
- [x] Works on mobile (≤600px) and desktop <!-- serving-layer change, no visual change -->
- [x] Correct terminology: street hockey / ball hockey, players/forwards/defense/goalies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cr6obsDvFNwCND18xAaon

---
_Generated by [Claude Code](https://claude.ai/code/session_017cr6obsDvFNwCND18xAaon)_