### PR TITLE
Add season history and champions to the standings page

### DIFF
--- a/core/tests/test_standings.py
+++ b/core/tests/test_standings.py
@@ -670,6 +670,7 @@ class StandingsViewContextTest(TestCase):
         Team_Stat.objects.create(
             team=self.team_a,
             division=self.division,
+            season=self.season,
             win=3,
             otw=1,
             otl=1,
@@ -682,6 +683,7 @@ class StandingsViewContextTest(TestCase):
         Team_Stat.objects.create(
             team=self.team_b,
             division=self.division,
+            season=self.season,
             win=1,
             otw=0,
             otl=0,
@@ -738,26 +740,289 @@ class StandingsViewContextTest(TestCase):
         bravo = next(t for t in teams if t.team.team_name == "Bravo")
         self.assertEqual(bravo.goal_differential, -15)  # 10 - 25
 
-    def test_inactive_team_excluded(self):
-        from leagues.models import Team, Team_Stat
+    def test_old_season_team_excluded_by_default(self):
+        """Regression: the default view must show only each division's latest
+        season, never a mix of seasons (the old is_active filter allowed teams
+        from two seasons to appear together)."""
+        from leagues.models import Season, Team, Team_Stat
 
-        inactive = Team.objects.create(
-            team_name="Inactive",
+        old_season = Season.objects.create(year=2024, season_type=3)
+        old_team = Team.objects.create(
+            team_name="Old Season Team",
             team_color="Grey",
             division=self.division,
-            season=self.season,
-            is_active=False,
+            season=old_season,
+            is_active=True,
         )
         Team_Stat.objects.create(
-            team=inactive,
+            team=old_team,
             division=self.division,
+            season=old_season,
             win=10,
             goals_for=50,
             goals_against=10,
         )
         teams = self._get().context["sunday_d1"]
         names = [t.team.team_name for t in teams]
-        self.assertNotIn("Inactive", names)
+        self.assertNotIn("Old Season Team", names)
+        self.assertEqual(names, ["Alpha", "Bravo"])
+
+
+class StandingsSeasonSelectionTest(TestCase):
+    """Tests for the per-section season dropdown on the standings page."""
+
+    def setUp(self):
+        from leagues.models import Division, Season, Team, Team_Stat
+
+        self.client = Client()
+        self.d1 = Division.objects.create(division=1)  # Sunday D1
+        self.d2 = Division.objects.create(division=2)  # Sunday D2
+        self.monday_a = Division.objects.create(division=4)  # Monday A
+        self.old_season = Season.objects.create(year=2025, season_type=3)  # Fall
+        self.new_season = Season.objects.create(year=2026, season_type=1)  # Spring
+
+        def make(name, division, season, win=1):
+            team = Team.objects.create(
+                team_name=name,
+                team_color="Red",
+                division=division,
+                season=season,
+                is_active=season == self.new_season,
+            )
+            Team_Stat.objects.create(
+                team=team,
+                division=division,
+                season=season,
+                win=win,
+                goals_for=10,
+                goals_against=5,
+            )
+            return team
+
+        # D1 played both seasons; D2 only played the older season.
+        make("D1 Old", self.d1, self.old_season)
+        make("D1 New", self.d1, self.new_season)
+        make("D2 Old", self.d2, self.old_season)
+
+    def _get(self, **params):
+        from django.urls import reverse
+
+        return self.client.get(reverse("team_standings"), params)
+
+    def test_default_shows_latest_season_per_division(self):
+        """With no params, each division independently shows its own latest
+        season — D1 its 2026 season, D2 its 2025 season."""
+        ctx = self._get().context
+        self.assertEqual([t.team.team_name for t in ctx["sunday_d1"]], ["D1 New"])
+        self.assertEqual([t.team.team_name for t in ctx["sunday_d2"]], ["D2 Old"])
+        self.assertEqual(ctx["sunday_d1_season"], "Spring 2026")
+        self.assertEqual(ctx["sunday_d2_season"], "Fall 2025")
+
+    def test_season_param_shows_historical_standings(self):
+        ctx = self._get(sunday=self.old_season.id).context
+        self.assertEqual([t.team.team_name for t in ctx["sunday_d1"]], ["D1 Old"])
+        self.assertEqual(ctx["sunday_d1_season"], "Fall 2025")
+        self.assertEqual(ctx["sunday_selected"], self.old_season.id)
+
+    def test_selected_season_applies_to_whole_section(self):
+        """Choosing 2026 for Sunday empties D2, which didn't play that season."""
+        ctx = self._get(sunday=self.new_season.id).context
+        self.assertEqual([t.team.team_name for t in ctx["sunday_d1"]], ["D1 New"])
+        self.assertEqual(ctx["sunday_d2"], [])
+
+    def test_invalid_season_param_falls_back_to_default(self):
+        for bad in ("junk", "999999", ""):
+            response = self._get(sunday=bad)
+            self.assertEqual(response.status_code, 200)
+            names = [t.team.team_name for t in response.context["sunday_d1"]]
+            self.assertEqual(names, ["D1 New"])
+            self.assertIsNone(response.context["sunday_selected"])
+
+    def test_inactive_teams_shown_for_their_season(self):
+        """Historical teams are inactive but must still appear when their
+        season is selected."""
+        ctx = self._get(sunday=self.old_season.id).context
+        self.assertEqual([t.team.team_name for t in ctx["sunday_d1"]], ["D1 Old"])
+
+    def test_dropdown_lists_only_seasons_with_section_data(self):
+        ctx = self._get().context
+        sunday_labels = [opt["label"] for opt in ctx["sunday_seasons"]]
+        self.assertEqual(sunday_labels, ["Spring 2026", "Fall 2025"])  # newest first
+        self.assertEqual(ctx["monday_seasons"], [])  # Monday never played
+
+    def test_duplicate_season_names_get_session_labels(self):
+        """Two real seasons that share a display name (e.g. two Monday sessions
+        both labeled Spring 2025) must be distinguishable in the dropdown."""
+        from leagues.models import Season, Team, Team_Stat
+
+        dup_a = Season.objects.create(year=2025, season_type=1)
+        dup_b = Season.objects.create(year=2025, season_type=1)
+        for i, season in enumerate([dup_a, dup_b]):
+            team = Team.objects.create(
+                team_name=f"Monday Team {i}",
+                team_color="Blue",
+                division=self.monday_a,
+                season=season,
+                is_active=False,
+            )
+            Team_Stat.objects.create(
+                team=team, division=self.monday_a, season=season, win=1
+            )
+        ctx = self._get().context
+        monday_labels = [opt["label"] for opt in ctx["monday_seasons"]]
+        self.assertEqual(
+            monday_labels, ["Spring 2025 (Session 2)", "Spring 2025 (Session 1)"]
+        )
+
+    def test_season_dropdown_rendered_per_section_with_data(self):
+        """Each section that has stats gets its own dropdown; sections with no
+        stats at all (here: Wednesday, Monday) get none."""
+        content = self._get().content.decode()
+        self.assertIn('id="season-sunday"', content)
+        self.assertNotIn('id="season-wednesday"', content)
+        self.assertNotIn('id="season-monday"', content)
+        self.assertIn("Fall 2025", content)
+
+    def test_current_option_shown_when_division_seasons_diverge(self):
+        """D1's latest is 2026 but D2's is 2025, so Sunday needs an explicit
+        'Current' choice meaning 'each division's own latest season'."""
+        response = self._get()
+        self.assertTrue(response.context["sunday_show_current"])
+        self.assertIsNone(response.context["sunday_selected"])
+        self.assertIn(">Current</option>", response.content.decode())
+
+    def test_current_option_hidden_when_division_seasons_align(self):
+        """When every division in a section is in the same latest season,
+        'Current' would duplicate that season's option, so it is dropped and
+        the latest season is preselected instead."""
+        from leagues.models import Team, Team_Stat
+
+        d2_new = Team.objects.create(
+            team_name="D2 New",
+            team_color="Red",
+            division=self.d2,
+            season=self.new_season,
+            is_active=True,
+        )
+        Team_Stat.objects.create(
+            team=d2_new, division=self.d2, season=self.new_season, win=1
+        )
+        response = self._get()
+        self.assertFalse(response.context["sunday_show_current"])
+        self.assertEqual(response.context["sunday_selected"], self.new_season.id)
+        content = response.content.decode()
+        self.assertNotIn(">Current</option>", content)
+        self.assertIn(
+            f'<option value="{self.new_season.id}" selected>Spring 2026</option>',
+            content,
+        )
+
+
+class StandingsChampionTest(TestCase):
+    """Tests for the champion banner shown with a division's standings."""
+
+    def setUp(self):
+        import datetime
+
+        from leagues.models import (
+            Division,
+            MatchUp,
+            Player,
+            Season,
+            Stat,
+            Team,
+            Team_Stat,
+            Week,
+        )
+
+        self.client = Client()
+        self.d1 = Division.objects.create(division=1)  # Sunday D1
+        self.d2 = Division.objects.create(division=2)  # Sunday D2
+        self.old_season = Season.objects.create(year=2025, season_type=3)  # Fall
+        self.new_season = Season.objects.create(year=2026, season_type=1)  # Spring
+
+        def make_team(name, division, season):
+            team = Team.objects.create(
+                team_name=name,
+                team_color="Red",
+                division=division,
+                season=season,
+                is_active=season == self.new_season,
+            )
+            Team_Stat.objects.create(team=team, division=division, season=season, win=1)
+            return team
+
+        self.winner = make_team("Old Winners", self.d1, self.old_season)
+        self.runner_up = make_team("Old Runners Up", self.d1, self.old_season)
+        make_team("D1 Current", self.d1, self.new_season)
+        make_team("D2 Old", self.d2, self.old_season)
+
+        week = Week.objects.create(
+            division=self.d1,
+            season=self.old_season,
+            date=datetime.date(2025, 11, 23),
+        )
+        self.final = MatchUp.objects.create(
+            week=week,
+            time=datetime.time(19, 0),
+            hometeam=self.winner,
+            awayteam=self.runner_up,
+            is_postseason=True,
+            is_championship=True,
+        )
+        scorer = Player.objects.create(first_name="Casey", last_name="Center")
+        opponent = Player.objects.create(first_name="Willa", last_name="Wing")
+        Stat.objects.create(
+            player=scorer, team=self.winner, matchup=self.final, goals=3
+        )
+        Stat.objects.create(
+            player=opponent, team=self.runner_up, matchup=self.final, goals=1
+        )
+
+    def _get(self, **params):
+        from django.urls import reverse
+
+        return self.client.get(reverse("team_standings"), params)
+
+    def test_champion_shown_for_selected_season(self):
+        response = self._get(sunday=self.old_season.id)
+        champ = response.context["sunday_d1_champion"]
+        self.assertIsNotNone(champ)
+        self.assertEqual(champ.team_name, "Old Winners")
+        content = response.content.decode()
+        self.assertIn("Champions: <strong>Old Winners</strong>", content)
+        self.assertIn("champ-trophy", content)
+
+    def test_no_champion_for_division_without_final(self):
+        response = self._get(sunday=self.old_season.id)
+        self.assertIsNone(response.context["sunday_d2_champion"])
+
+    def test_no_champion_on_default_view_without_decided_final(self):
+        """The current D1 season has no championship game, so the default view
+        must not show a champion banner for it."""
+        response = self._get()
+        self.assertIsNone(response.context["sunday_d1_champion"])
+        self.assertNotIn("champion-banner", response.content.decode())
+
+    def test_unplayed_final_produces_no_champion(self):
+        """A scheduled final with no stats yet (0-0) must not crown anyone."""
+        from leagues.models import Stat
+
+        Stat.objects.filter(matchup=self.final).delete()
+        response = self._get(sunday=self.old_season.id)
+        self.assertIsNone(response.context["sunday_d1_champion"])
+
+    def test_tied_final_produces_no_champion(self):
+        from leagues.models import Stat
+
+        Stat.objects.filter(team=self.runner_up).update(goals=3)
+        response = self._get(sunday=self.old_season.id)
+        self.assertIsNone(response.context["sunday_d1_champion"])
+
+    def test_championship_results_empty_pairs(self):
+        from core.views.standings import championship_results
+
+        self.assertEqual(championship_results([]), {})
 
 
 if __name__ == "__main__":

--- a/core/views/standings.py
+++ b/core/views/standings.py
@@ -1,22 +1,19 @@
-from django.db.models import Q, Sum
-from django.db.models.functions import Coalesce
-from django.views.generic.list import ListView
+from collections import Counter
 
-from leagues.models import MatchUp, Team_Stat
+from django.db.models import Q, Sum
+from django.views.generic import TemplateView
+
+from leagues.models import MatchUp, Season, Stat, Team_Stat
 
 from .schedule import add_goals_for_matchups
 
-
-class ListAsQuerySet(list):
-    def __init__(self, *args, model, **kwargs):
-        self.model = model
-        super().__init__(*args, **kwargs)
-
-    def filter(self, *args, **kwargs):
-        return self  # filter ignoring, but you can impl custom filter
-
-    def order_by(self, *args, **kwargs):
-        return self
+# Sections shown on the standings page. Each section shares one season
+# dropdown because its divisions run on the same night and calendar.
+SECTION_DIVISIONS = {
+    "sunday": (1, 2),
+    "wednesday": (3,),
+    "monday": (4, 5),
+}
 
 
 def check_goal_diff(team1, team2):
@@ -69,204 +66,222 @@ def check_h2h_record(team1, team2):
     return False
 
 
-class TeamStatDetailView(ListView):
-    context_object_name = "team_list"
+def season_display_name(season):
+    return "%s %s" % (season.get_season_type_display(), season.year)
 
-    def get_queryset(self):
-        # Need to get divisions separately to account for d1 and d2 team having
-        # same number of points (could cause bug in h2h comparison)
-        # Note: Season filtering temporarily disabled - shows all seasons aggregated
 
-        team_stat_list = []
-        d1_team_stat_list = list(
-            Team_Stat.objects.filter(team__is_active=True)
-            .filter(division=1)
-            .select_related("team")
-            .annotate(
-                total_points=Coalesce(
-                    (Sum("win") * 3) + (Sum("otw") * 2) + Sum("tie") + Sum("otl"), 0
-                ),
-                total_wins=Coalesce(Sum("win") + Sum("otw"), 0),
-                regulation_wins=Coalesce(Sum("win"), 0),  # Add regulation wins
-            )
-            .order_by(
-                "-total_points",
-                "-regulation_wins",
-                "-total_wins",
-                "-tie",
-                "-otl",
-                "-goals_for",
-                "-goals_against",
-            )
+def apply_tiebreakers(stats):
+    """Order Team_Stat rows for one division by points, then the league
+    tiebreakers: regulation wins → head-to-head → goal differential."""
+    for ts in stats:
+        ts.total_points = (ts.win * 3) + (ts.otw * 2) + ts.tie + ts.otl
+        ts.regulation_wins = ts.win
+        ts.total_wins = ts.win + ts.otw
+        ts.gp = ts.win + ts.otw + ts.otl + ts.loss + ts.tie
+        ts.goal_differential = ts.goals_for - ts.goals_against
+
+    stats.sort(
+        key=lambda ts: (
+            -ts.total_points,
+            -ts.regulation_wins,
+            -ts.total_wins,
+            -ts.tie,
+            -ts.otl,
+            -ts.goals_for,
+            -ts.goals_against,
         )
-        d2_team_stat_list = list(
-            Team_Stat.objects.filter(team__is_active=True)
-            .filter(division=2)
-            .select_related("team")
-            .annotate(
-                total_points=Coalesce(
-                    (Sum("win") * 3) + (Sum("otw") * 2) + Sum("tie") + Sum("otl"), 0
-                ),
-                total_wins=Coalesce(Sum("win") + Sum("otw"), 0),
-                regulation_wins=Coalesce(Sum("win"), 0),  # Add regulation wins
-            )
-            .order_by(
-                "-total_points",
-                "-regulation_wins",
-                "-total_wins",
-                "-tie",
-                "-otl",
-                "-goals_for",
-                "-goals_against",
-            )
-        )
-        draft_team_stat_list = list(
-            Team_Stat.objects.filter(team__is_active=True)
-            .filter(division=3)
-            .select_related("team")
-            .annotate(
-                total_points=Coalesce(
-                    (Sum("win") * 3) + (Sum("otw") * 2) + Sum("tie") + Sum("otl"), 0
-                ),
-                total_wins=Coalesce(Sum("win") + Sum("otw"), 0),
-                regulation_wins=Coalesce(Sum("win"), 0),  # Add regulation wins
-            )
-            .order_by(
-                "-total_points",
-                "-regulation_wins",
-                "-win",
-                "loss",
-                "-tie",
-                "-otl",
-                "-goals_for",
-                "-goals_against",
-            )
-        )
-        monday_a_team_stat_list = list(
-            Team_Stat.objects.filter(team__is_active=True)
-            .filter(division=4)
-            .select_related("team")
-            .annotate(
-                total_points=Coalesce(
-                    (Sum("win") * 3) + (Sum("otw") * 2) + Sum("tie") + Sum("otl"), 0
-                ),
-                total_wins=Coalesce(Sum("win") + Sum("otw"), 0),
-                regulation_wins=Coalesce(Sum("win"), 0),  # Add regulation wins
-            )
-            .order_by(
-                "-total_points",
-                "-regulation_wins",
-                "-total_wins",
-                "-tie",
-                "-otl",
-                "-goals_for",
-                "-goals_against",
-            )
-        )
-        monday_b_team_stat_list = list(
-            Team_Stat.objects.filter(team__is_active=True)
-            .filter(division=5)
-            .select_related("team")
-            .annotate(
-                total_points=Coalesce(
-                    (Sum("win") * 3) + (Sum("otw") * 2) + Sum("tie") + Sum("otl"), 0
-                ),
-                total_wins=Coalesce(Sum("win") + Sum("otw"), 0),
-                regulation_wins=Coalesce(Sum("win"), 0),  # Add regulation wins
-            )
-            .order_by(
-                "-total_points",
-                "-regulation_wins",
-                "-total_wins",
-                "-tie",
-                "-otl",
-                "-goals_for",
-                "-goals_against",
-            )
-        )
+    )
 
-        team_stat_list = (
-            d1_team_stat_list
-            + d2_team_stat_list
-            + draft_team_stat_list
-            + monday_a_team_stat_list
-            + monday_b_team_stat_list
-        )
+    for i in range(1, len(stats)):
+        if stats[i].total_points == stats[i - 1].total_points:
+            if stats[i].regulation_wins != stats[i - 1].regulation_wins:
+                need_swap = stats[i].regulation_wins > stats[i - 1].regulation_wins
+            elif check_teams_play(stats[i], stats[i - 1]):
+                need_swap = check_h2h_record(stats[i], stats[i - 1])
+            else:
+                need_swap = check_goal_diff(stats[i], stats[i - 1])
+            if need_swap:
+                stats[i], stats[i - 1] = stats[i - 1], stats[i]
 
-        for i in range(len(team_stat_list)):
-            if (
-                i > 0
-                and team_stat_list[i].total_points == team_stat_list[i - 1].total_points
-            ):
-                need_swap = False
+    return stats
 
-                # First tiebreaker: Regulation wins
-                if (
-                    team_stat_list[i].regulation_wins
-                    != team_stat_list[i - 1].regulation_wins
-                ):
-                    # Team with more regulation wins should be higher
-                    need_swap = (
-                        team_stat_list[i].regulation_wins
-                        > team_stat_list[i - 1].regulation_wins
-                    )
-                else:
-                    # Second tiebreaker: Head-to-head (if teams have played)
-                    teams_played = check_teams_play(
-                        team_stat_list[i], team_stat_list[i - 1]
-                    )
-                    if teams_played:
-                        need_swap = check_h2h_record(
-                            team_stat_list[i], team_stat_list[i - 1]
-                        )
-                    else:
-                        # Third tiebreaker: Goal differential (if no H2H or tied reg wins)
-                        need_swap = check_goal_diff(
-                            team_stat_list[i], team_stat_list[i - 1]
-                        )
 
-                if need_swap:
-                    team_stat_list[i], team_stat_list[i - 1] = (
-                        team_stat_list[i - 1],
-                        team_stat_list[i],
-                    )
+def championship_results(pairs):
+    """Winner of the championship game for each (division, season_id) pair.
 
-        return ListAsQuerySet(team_stat_list, model=Team_Stat)
+    Returns {division int: Team}. A final that is unplayed or tied (no clear
+    winner yet) produces no entry, so in-progress playoffs never show a
+    premature champion.
+    """
+    if not pairs:
+        return {}
+    query = Q()
+    for division, season_id in pairs:
+        query |= Q(week__division__division=division, week__season_id=season_id)
+    matchups = list(
+        MatchUp.objects.filter(is_championship=True)
+        .filter(query)
+        .select_related("hometeam", "awayteam", "week__division")
+        .order_by("week__date")
+    )
+    goals = {}
+    for row in (
+        Stat.objects.filter(matchup__in=matchups)
+        .values("matchup_id", "team_id")
+        .annotate(total=Sum("goals"))
+    ):
+        goals[(row["matchup_id"], row["team_id"])] = row["total"] or 0
+    winners = {}
+    for matchup in matchups:
+        home = goals.get((matchup.id, matchup.hometeam_id), 0)
+        away = goals.get((matchup.id, matchup.awayteam_id), 0)
+        if home != away:
+            winners[matchup.week.division.division] = (
+                matchup.hometeam if home > away else matchup.awayteam
+            )
+    return winners
+
+
+class TeamStatDetailView(TemplateView):
+    template_name = "leagues/team_stat_list.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        team_list = list(context["team_list"])
 
-        for ts in team_list:
-            ts.gp = ts.win + ts.otw + ts.otl + ts.loss + ts.tie
-            ts.goal_differential = ts.goals_for - ts.goals_against
+        seasons = {
+            s.id: s for s in Season.objects.filter(team_stat__isnull=False).distinct()
+        }
 
-        def _ranked(teams):
+        def chronology(season_id):
+            season = seasons[season_id]
+            return (season.year, season.season_type or 0, season_id)
+
+        # Seasons each division has stats for, newest first.
+        division_seasons = {}
+        for division, season_id in set(
+            Team_Stat.objects.exclude(season__isnull=True).values_list(
+                "division__division", "season_id"
+            )
+        ):
+            division_seasons.setdefault(division, []).append(season_id)
+        for season_ids in division_seasons.values():
+            season_ids.sort(key=chronology, reverse=True)
+
+        # One picker per section: which seasons it offers and which is chosen.
+        selected = {}
+        for section, divisions in SECTION_DIVISIONS.items():
+            option_ids = sorted(
+                {
+                    sid
+                    for division in divisions
+                    for sid in division_seasons.get(division, [])
+                },
+                key=chronology,
+                reverse=True,
+            )
+            raw = self.request.GET.get(section, "")
+            selected_id = int(raw) if raw.isdigit() and int(raw) in seasons else None
+            if selected_id not in option_ids:
+                selected_id = None
+            if selected_id is not None:
+                selected[section] = selected_id
+
+            # A "Current" choice only exists when the section's divisions are
+            # in different seasons (e.g. one has started its next season and
+            # the other hasn't). When they agree, "Current" would duplicate
+            # the newest season option, so preselect that season instead.
+            latest_ids = {
+                division_seasons[division][0]
+                for division in divisions
+                if division_seasons.get(division)
+            }
+            diverged = len(latest_ids) > 1
+            display_id = selected_id
+            if display_id is None and not diverged and latest_ids:
+                display_id = next(iter(latest_ids))
+
+            context[f"{section}_seasons"] = self._labeled_options(
+                option_ids, seasons, chronology
+            )
+            context[f"{section}_selected"] = display_id
+            context[f"{section}_show_current"] = diverged
+        context["picker_selected"] = selected
+
+        displayed = {}  # division int -> season id shown
+
+        def standings_for(section, division):
+            season_id = selected.get(section)
+            if season_id is None:
+                latest = division_seasons.get(division, [])
+                season_id = latest[0] if latest else None
+            if season_id is None:
+                return [], None
+            displayed[division] = season_id
+            stats = list(
+                Team_Stat.objects.filter(
+                    division__division=division, season_id=season_id
+                ).select_related("team", "season")
+            )
+            return apply_tiebreakers(stats), season_display_name(seasons[season_id])
+
+        def ranked(teams):
             for i, ts in enumerate(teams):
                 ts.rank = i + 1
             return teams
 
-        wed_all = [t for t in team_list if str(t.division) == "Wednesday Draft League"]
+        sunday_d1, sunday_d1_season = standings_for("sunday", 1)
+        sunday_d2, sunday_d2_season = standings_for("sunday", 2)
+        wednesday, wednesday_season = standings_for("wednesday", 3)
+        monday_a, monday_a_season = standings_for("monday", 4)
+        monday_b, monday_b_season = standings_for("monday", 5)
+
+        champions = championship_results(list(displayed.items()))
+
+        def champion_for(division, teams):
+            # Attach the champion to the table it appears in — for Wednesday
+            # this picks the champion's conference automatically.
+            champ = champions.get(division)
+            if champ and any(ts.team_id == champ.id for ts in teams):
+                return champ
+            return None
+
+        wednesday_east = ranked([t for t in wednesday if t.team.conference == 1])
+        wednesday_west = ranked([t for t in wednesday if t.team.conference == 2])
         context.update(
             {
-                "sunday_d1": _ranked(
-                    [t for t in team_list if str(t.division) == "Sunday D1"]
-                ),
-                "sunday_d2": _ranked(
-                    [t for t in team_list if str(t.division) == "Sunday D2"]
-                ),
-                "wednesday_east": _ranked(
-                    [t for t in wed_all if t.team.conference == 1]
-                ),
-                "wednesday_west": _ranked(
-                    [t for t in wed_all if t.team.conference == 2]
-                ),
-                "monday_a": _ranked(
-                    [t for t in team_list if str(t.division) == "Monday A League"]
-                ),
-                "monday_b": _ranked(
-                    [t for t in team_list if str(t.division) == "Monday B League"]
-                ),
+                "sunday_d1": ranked(sunday_d1),
+                "sunday_d2": ranked(sunday_d2),
+                "wednesday_east": wednesday_east,
+                "wednesday_west": wednesday_west,
+                "monday_a": ranked(monday_a),
+                "monday_b": ranked(monday_b),
+                "sunday_d1_season": sunday_d1_season,
+                "sunday_d2_season": sunday_d2_season,
+                "wednesday_season": wednesday_season,
+                "monday_a_season": monday_a_season,
+                "monday_b_season": monday_b_season,
+                "sunday_d1_champion": champion_for(1, sunday_d1),
+                "sunday_d2_champion": champion_for(2, sunday_d2),
+                "wednesday_east_champion": champion_for(3, wednesday_east),
+                "wednesday_west_champion": champion_for(3, wednesday_west),
+                "monday_a_champion": champion_for(4, monday_a),
+                "monday_b_champion": champion_for(5, monday_b),
             }
         )
         return context
+
+    @staticmethod
+    def _labeled_options(option_ids, seasons, chronology):
+        """Build dropdown options, numbering sessions when two seasons share a
+        display name (e.g. two Monday sessions both labeled Spring 2025)."""
+        names = Counter(season_display_name(seasons[sid]) for sid in option_ids)
+        session = Counter()
+        labels = {}
+        for sid in sorted(option_ids, key=chronology):
+            name = season_display_name(seasons[sid])
+            if names[name] > 1:
+                session[name] += 1
+                labels[sid] = f"{name} (Session {session[name]})"
+            else:
+                labels[sid] = name
+        return [{"id": sid, "label": labels[sid]} for sid in option_ids]

--- a/leagues/templates/leagues/team_stat_list.html
+++ b/leagues/templates/leagues/team_stat_list.html
@@ -33,46 +33,55 @@
             <p class="description">Click a team name to see full details.</p>
 
             <!-- Sunday -->
-            <div class="standings-section">
-                <h3 class="standings-section-title">Sunday</h3>
+            <div class="standings-section" id="sunday">
+                <div class="standings-section-header">
+                    <h3 class="standings-section-title">Sunday</h3>
+                    {% include "partials/standings_season_picker.html" with param="sunday" options=sunday_seasons selected=sunday_selected show_current=sunday_show_current all_selected=picker_selected %}
+                </div>
                 <div class="standings-split">
                     <div class="standings-group">
-                        <div class="standings-group-label">D1</div>
-                        {% include "partials/standings_table.html" with teams=sunday_d1 %}
+                        <div class="standings-group-label"><span>D1{% if sunday_d1_season %} <span class="season-chip">{{ sunday_d1_season }}</span>{% endif %}</span>{% if sunday_d1_champion %}<span class="champion-banner">🏆 Champions: <strong>{{ sunday_d1_champion.team_name }}</strong></span>{% endif %}</div>
+                        {% include "partials/standings_table.html" with teams=sunday_d1 champion_id=sunday_d1_champion.id %}
                     </div>
                     <div class="standings-group">
-                        <div class="standings-group-label">D2</div>
-                        {% include "partials/standings_table.html" with teams=sunday_d2 %}
+                        <div class="standings-group-label"><span>D2{% if sunday_d2_season %} <span class="season-chip">{{ sunday_d2_season }}</span>{% endif %}</span>{% if sunday_d2_champion %}<span class="champion-banner">🏆 Champions: <strong>{{ sunday_d2_champion.team_name }}</strong></span>{% endif %}</div>
+                        {% include "partials/standings_table.html" with teams=sunday_d2 champion_id=sunday_d2_champion.id %}
                     </div>
                 </div>
             </div>
 
             <!-- Wednesday Draft League -->
-            <div class="standings-section">
-                <h3 class="standings-section-title">Wednesday Draft League</h3>
+            <div class="standings-section" id="wednesday">
+                <div class="standings-section-header">
+                    <h3 class="standings-section-title">Wednesday Draft League</h3>
+                    {% include "partials/standings_season_picker.html" with param="wednesday" options=wednesday_seasons selected=wednesday_selected show_current=wednesday_show_current all_selected=picker_selected %}
+                </div>
                 <div class="standings-split">
                     <div class="standings-group">
-                        <div class="standings-group-label">East</div>
-                        {% include "partials/standings_table.html" with teams=wednesday_east %}
+                        <div class="standings-group-label"><span>East{% if wednesday_season %} <span class="season-chip">{{ wednesday_season }}</span>{% endif %}</span>{% if wednesday_east_champion %}<span class="champion-banner">🏆 Champions: <strong>{{ wednesday_east_champion.team_name }}</strong></span>{% endif %}</div>
+                        {% include "partials/standings_table.html" with teams=wednesday_east champion_id=wednesday_east_champion.id %}
                     </div>
                     <div class="standings-group">
-                        <div class="standings-group-label">West</div>
-                        {% include "partials/standings_table.html" with teams=wednesday_west %}
+                        <div class="standings-group-label"><span>West{% if wednesday_season %} <span class="season-chip">{{ wednesday_season }}</span>{% endif %}</span>{% if wednesday_west_champion %}<span class="champion-banner">🏆 Champions: <strong>{{ wednesday_west_champion.team_name }}</strong></span>{% endif %}</div>
+                        {% include "partials/standings_table.html" with teams=wednesday_west champion_id=wednesday_west_champion.id %}
                     </div>
                 </div>
             </div>
 
             <!-- Monday Coed -->
-            <div class="standings-section">
-                <h3 class="standings-section-title">Monday Coed</h3>
+            <div class="standings-section" id="monday">
+                <div class="standings-section-header">
+                    <h3 class="standings-section-title">Monday Coed</h3>
+                    {% include "partials/standings_season_picker.html" with param="monday" options=monday_seasons selected=monday_selected show_current=monday_show_current all_selected=picker_selected %}
+                </div>
                 <div class="standings-split">
                     <div class="standings-group">
-                        <div class="standings-group-label">A League</div>
-                        {% include "partials/standings_table.html" with teams=monday_a %}
+                        <div class="standings-group-label"><span>A League{% if monday_a_season %} <span class="season-chip">{{ monday_a_season }}</span>{% endif %}</span>{% if monday_a_champion %}<span class="champion-banner">🏆 Champions: <strong>{{ monday_a_champion.team_name }}</strong></span>{% endif %}</div>
+                        {% include "partials/standings_table.html" with teams=monday_a champion_id=monday_a_champion.id %}
                     </div>
                     <div class="standings-group">
-                        <div class="standings-group-label">B League</div>
-                        {% include "partials/standings_table.html" with teams=monday_b %}
+                        <div class="standings-group-label"><span>B League{% if monday_b_season %} <span class="season-chip">{{ monday_b_season }}</span>{% endif %}</span>{% if monday_b_champion %}<span class="champion-banner">🏆 Champions: <strong>{{ monday_b_champion.team_name }}</strong></span>{% endif %}</div>
+                        {% include "partials/standings_table.html" with teams=monday_b champion_id=monday_b_champion.id %}
                     </div>
                 </div>
             </div>

--- a/leagues/templates/partials/standings_season_picker.html
+++ b/leagues/templates/partials/standings_season_picker.html
@@ -1,0 +1,21 @@
+{% comment %}
+Season dropdown for one standings section.
+Expects: param (section key), options (list of {id, label}), selected (id or
+None), show_current (bool — offered only when the section's divisions are in
+different seasons), all_selected (dict of explicitly chosen section params to
+preserve across pickers).
+{% endcomment %}
+{% if options %}
+<form method="get" action="{% url 'team_standings' %}#{{ param }}" class="season-picker">
+    <label class="season-picker-label" for="season-{{ param }}">Season</label>
+    <select id="season-{{ param }}" name="{{ param }}" onchange="this.form.submit()">
+        {% if show_current %}<option value=""{% if selected is None %} selected{% endif %}>Current</option>{% endif %}
+        {% for opt in options %}
+        <option value="{{ opt.id }}" {% if opt.id == selected %}selected{% endif %}>{{ opt.label }}</option>
+        {% endfor %}
+    </select>
+    {% for key, value in all_selected.items %}
+        {% if key != param %}<input type="hidden" name="{{ key }}" value="{{ value }}">{% endif %}
+    {% endfor %}
+</form>
+{% endif %}

--- a/leagues/templates/partials/standings_table.html
+++ b/leagues/templates/partials/standings_table.html
@@ -30,7 +30,7 @@
         <tbody>
             {% for ts in teams %}
             <tr class="clickable" onclick="handleTeam('{% url "teams" ts.team.id %}')">
-                <td class="col-name"><a href="{% url 'teams' ts.team.id %}" class="cell-link">{{ ts.team.team_name }}</a></td>
+                <td class="col-name"><a href="{% url 'teams' ts.team.id %}" class="cell-link">{{ ts.team.team_name }}</a>{% if champion_id and ts.team.id == champion_id %} <span class="champ-trophy" role="img" aria-label="Season champions" title="Season champions">🏆</span>{% endif %}</td>
                 <td class="col-stat">{{ ts.win }}</td>
                 <td class="col-stat">{{ ts.otw }}</td>
                 <td class="col-stat">{{ ts.loss }}</td>
@@ -42,7 +42,7 @@
                 <td class="col-stat">{{ ts.gp }}</td>
             </tr>
             {% empty %}
-            <tr><td colspan="10" class="empty-msg">No stats entered yet.</td></tr>
+            <tr><td colspan="10" class="empty-msg">No games recorded for this season.</td></tr>
             {% endfor %}
         </tbody>
     </table>

--- a/static/assets/css/team_stat_list.css
+++ b/static/assets/css/team_stat_list.css
@@ -12,10 +12,87 @@
     padding-bottom: 6px;
     margin-bottom: 16px;
 }
+
+/* ── Section header (title + season picker) ─────────── */
+.standings-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 8px 16px;
+    border-bottom: 2px solid #e2e8f0;
+    padding-bottom: 6px;
+    margin-bottom: 16px;
+}
+.standings-section-header .standings-section-title {
+    border-bottom: none;
+    padding-bottom: 0;
+    margin-bottom: 0;
+}
+.season-picker {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.season-picker-label {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #718096;
+}
+.season-picker select {
+    font-size: 14px;
+    color: #2d3748;
+    background: #fff;
+    border: 1px solid #cbd5e0;
+    border-radius: 6px;
+    padding: 6px 10px;
+    min-height: 36px;
+    cursor: pointer;
+}
+.season-picker select:focus {
+    outline: 2px solid #2b6cb0;
+    outline-offset: 1px;
+}
+.season-chip {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    color: #a0aec0;
+    margin-left: 6px;
+}
+
+/* ── Champion banner & row marker ───────────────────── */
+.champion-banner {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 12px;
+    text-transform: none;
+    letter-spacing: normal;
+    color: #744210;
+    background: #fefcbf;
+    border: 1px solid #f6e05e;
+    border-radius: 6px;
+    padding: 2px 8px;
+}
+.champion-banner strong {
+    color: #744210;
+}
+.champ-trophy {
+    font-size: 13px;
+    margin-left: 4px;
+}
 .standings-group {
     margin-bottom: 20px;
 }
 .standings-group-label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 4px 12px;
     font-size: 0.78em;
     font-weight: 700;
     text-transform: uppercase;
@@ -299,4 +376,13 @@
     .team-stats-table col.col-stat { width: 44px; }
     /* Tooltips are hover-only — not relevant on touch devices */
     .team-stats-table thead th.has-tip { cursor: default; }
+    /* Season picker: full-width row with a 44px touch target */
+    .season-picker {
+        width: 100%;
+    }
+    .season-picker select {
+        flex: 1;
+        min-height: 44px;
+        font-size: 15px;
+    }
 }


### PR DESCRIPTION
## Summary
- Season dropdown per standings section (Sunday / Wednesday / Monday) for viewing any past season's regular-season standings; options list only seasons that section actually played
- "Current" option appears only when a section's divisions are in different seasons (e.g. one division has started its next season); otherwise the latest season is preselected to avoid a duplicate choice
- Standings now filter by explicit season instead of `team.is_active`, fixing mixed-season tables (D2 was rendering 20 teams from two seasons) and collapsing five duplicated per-division query blocks into one helper
- Season champions (derived from the `is_championship` matchup) shown as a chip on the division label row plus a trophy on the champion's table row; unplayed or tied finals never crown a premature champion
- Duplicate season names disambiguated as sessions (e.g. the two Monday "Spring 2025" seasons)

## Test plan
- 14 new unit/integration tests in `core/tests/test_standings.py` (season selection, invalid params, divergence rules, dropdown rendering, champion derivation edge cases)
- Full suite passes (828 tests) incl. performance query-count ceilings
- Verified end-to-end against a fresh production data sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)