### PR TITLE
Refine champion placement on the standings page

### DIFF
--- a/core/tests/test_standings.py
+++ b/core/tests/test_standings.py
@@ -991,7 +991,78 @@ class StandingsChampionTest(TestCase):
         self.assertEqual(champ.team_name, "Old Winners")
         content = response.content.decode()
         self.assertIn("Champions: <strong>Old Winners</strong>", content)
-        self.assertIn("champ-trophy", content)
+        # Trophy must render inside the team-name link (cell-link is
+        # display:block, so a trailing sibling would wrap to its own line).
+        self.assertRegex(
+            content, r'class="cell-link">Old Winners <span class="champ-trophy"'
+        )
+
+    def test_wednesday_champion_is_league_level(self):
+        """East/West are conferences of one Wednesday league, so the champion
+        belongs to the section header, not to a conference table label."""
+        import datetime
+
+        from leagues.models import (
+            Division,
+            MatchUp,
+            Player,
+            Stat,
+            Team,
+            Team_Stat,
+            Week,
+        )
+
+        wednesday = Division.objects.create(division=3)
+
+        def make_team(name, conference):
+            team = Team.objects.create(
+                team_name=name,
+                team_color="Green",
+                division=wednesday,
+                season=self.old_season,
+                is_active=False,
+                conference=conference,
+            )
+            Team_Stat.objects.create(
+                team=team, division=wednesday, season=self.old_season, win=1
+            )
+            return team
+
+        east_team = make_team("East Winners", 1)
+        west_team = make_team("West Runners Up", 2)
+        week = Week.objects.create(
+            division=wednesday,
+            season=self.old_season,
+            date=datetime.date(2025, 11, 26),
+        )
+        final = MatchUp.objects.create(
+            week=week,
+            time=datetime.time(19, 0),
+            hometeam=east_team,
+            awayteam=west_team,
+            is_postseason=True,
+            is_championship=True,
+        )
+        scorer = Player.objects.create(first_name="Dana", last_name="Defense")
+        Stat.objects.create(player=scorer, team=east_team, matchup=final, goals=2)
+
+        response = self._get(wednesday=self.old_season.id)
+        self.assertEqual(
+            response.context["wednesday_champion"].team_name, "East Winners"
+        )
+        self.assertNotIn("wednesday_east_champion", response.context)
+        self.assertNotIn("wednesday_west_champion", response.context)
+        content = response.content.decode()
+        # Banner appears once, in the section header before the East label.
+        self.assertEqual(content.count("Champions: <strong>East Winners</strong>"), 1)
+        header = content.split("Wednesday Draft League</h3>")[1].split(
+            'class="standings-split"'
+        )[0]
+        self.assertIn("Champions: <strong>East Winners</strong>", header)
+        # Trophy lands in the East table, where the champion's row is.
+        self.assertRegex(
+            content, r'class="cell-link">East Winners <span class="champ-trophy"'
+        )
 
     def test_no_champion_for_division_without_final(self):
         response = self._get(sunday=self.old_season.id)

--- a/core/views/standings.py
+++ b/core/views/standings.py
@@ -262,8 +262,9 @@ class TeamStatDetailView(TemplateView):
                 "monday_b_season": monday_b_season,
                 "sunday_d1_champion": champion_for(1, sunday_d1),
                 "sunday_d2_champion": champion_for(2, sunday_d2),
-                "wednesday_east_champion": champion_for(3, wednesday_east),
-                "wednesday_west_champion": champion_for(3, wednesday_west),
+                # East/West are conferences within one Wednesday league, so
+                # there is a single league champion, shown at section level.
+                "wednesday_champion": champion_for(3, wednesday),
                 "monday_a_champion": champion_for(4, monday_a),
                 "monday_b_champion": champion_for(5, monday_b),
             }

--- a/leagues/templates/leagues/team_stat_list.html
+++ b/leagues/templates/leagues/team_stat_list.html
@@ -54,16 +54,17 @@
             <div class="standings-section" id="wednesday">
                 <div class="standings-section-header">
                     <h3 class="standings-section-title">Wednesday Draft League</h3>
+                    {% if wednesday_champion %}<span class="champion-banner">🏆 Champions: <strong>{{ wednesday_champion.team_name }}</strong></span>{% endif %}
                     {% include "partials/standings_season_picker.html" with param="wednesday" options=wednesday_seasons selected=wednesday_selected show_current=wednesday_show_current all_selected=picker_selected %}
                 </div>
                 <div class="standings-split">
                     <div class="standings-group">
-                        <div class="standings-group-label"><span>East{% if wednesday_season %} <span class="season-chip">{{ wednesday_season }}</span>{% endif %}</span>{% if wednesday_east_champion %}<span class="champion-banner">🏆 Champions: <strong>{{ wednesday_east_champion.team_name }}</strong></span>{% endif %}</div>
-                        {% include "partials/standings_table.html" with teams=wednesday_east champion_id=wednesday_east_champion.id %}
+                        <div class="standings-group-label"><span>East{% if wednesday_season %} <span class="season-chip">{{ wednesday_season }}</span>{% endif %}</span></div>
+                        {% include "partials/standings_table.html" with teams=wednesday_east champion_id=wednesday_champion.id %}
                     </div>
                     <div class="standings-group">
-                        <div class="standings-group-label"><span>West{% if wednesday_season %} <span class="season-chip">{{ wednesday_season }}</span>{% endif %}</span>{% if wednesday_west_champion %}<span class="champion-banner">🏆 Champions: <strong>{{ wednesday_west_champion.team_name }}</strong></span>{% endif %}</div>
-                        {% include "partials/standings_table.html" with teams=wednesday_west champion_id=wednesday_west_champion.id %}
+                        <div class="standings-group-label"><span>West{% if wednesday_season %} <span class="season-chip">{{ wednesday_season }}</span>{% endif %}</span></div>
+                        {% include "partials/standings_table.html" with teams=wednesday_west champion_id=wednesday_champion.id %}
                     </div>
                 </div>
             </div>

--- a/leagues/templates/partials/standings_table.html
+++ b/leagues/templates/partials/standings_table.html
@@ -30,7 +30,7 @@
         <tbody>
             {% for ts in teams %}
             <tr class="clickable" onclick="handleTeam('{% url "teams" ts.team.id %}')">
-                <td class="col-name"><a href="{% url 'teams' ts.team.id %}" class="cell-link">{{ ts.team.team_name }}</a>{% if champion_id and ts.team.id == champion_id %} <span class="champ-trophy" role="img" aria-label="Season champions" title="Season champions">🏆</span>{% endif %}</td>
+                <td class="col-name"><a href="{% url 'teams' ts.team.id %}" class="cell-link">{{ ts.team.team_name }}{% if champion_id and ts.team.id == champion_id %} <span class="champ-trophy" role="img" aria-label="Season champions" title="Season champions">🏆</span>{% endif %}</a></td>
                 <td class="col-stat">{{ ts.win }}</td>
                 <td class="col-stat">{{ ts.otw }}</td>
                 <td class="col-stat">{{ ts.loss }}</td>

--- a/static/assets/css/team_stat_list.css
+++ b/static/assets/css/team_stat_list.css
@@ -17,12 +17,15 @@
 .standings-section-header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     flex-wrap: wrap;
     gap: 8px 16px;
     border-bottom: 2px solid #e2e8f0;
     padding-bottom: 6px;
     margin-bottom: 16px;
+}
+/* Title (and league-level champion, when present) sit left; picker right */
+.standings-section-header .season-picker {
+    margin-left: auto;
 }
 .standings-section-header .standings-section-title {
     border-bottom: none;


### PR DESCRIPTION
## Summary
- Trophy now renders inline after the team name in the standings table instead of wrapping to its own line (`.cell-link` is `display:block`, so the trailing trophy sibling was dropping down); moved it inside the link
- Wednesday East/West are conferences of a single draft league, so there is one league champion shown in the section header — replaced the two per-conference banners with a single `wednesday_champion`; the trophy still marks the winner's row in whichever conference table they appear in
- Sunday/Monday keep their per-division champion banners (those are genuinely separate divisions)

## Test plan
- Updated tests assert the trophy is inline within the team-name link and that the Wednesday champion is league-level (single header banner, not per-conference)
- Full suite passes (829 tests)
- Verified end-to-end against production data (Wednesday Fall 2025 champion renders once in the header with an inline trophy on the winner's row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)