### PR TITLE
Right-align the Wednesday champion banner in the section header

### DIFF
--- a/static/assets/css/team_stat_list.css
+++ b/static/assets/css/team_stat_list.css
@@ -23,11 +23,11 @@
     padding-bottom: 6px;
     margin-bottom: 16px;
 }
-/* Title (and league-level champion, when present) sit left; picker right */
-.standings-section-header .season-picker {
-    margin-left: auto;
-}
+/* Title stays left; everything after it (league champion banner, then the
+   season picker) is pushed right, so the Wednesday champion right-aligns like
+   the per-division banners in the other sections. */
 .standings-section-header .standings-section-title {
+    margin-right: auto;
     border-bottom: none;
     padding-bottom: 0;
     margin-bottom: 0;


### PR DESCRIPTION
## Summary
- The Wednesday league champion banner sat on the left next to the section title, unlike the Sunday/Monday per-division banners which right-align opposite their labels
- Give the section title `margin-right: auto` (instead of only pushing the season picker right), so the champion banner and picker both flow to the right edge — matching the "champions on the right" pattern used elsewhere
- Sunday/Monday headers are unchanged (no header banner; picker still right-aligned)

## Test plan
- CSS-only change; full suite passes (829 tests)
- Verified against production data that the Wednesday header renders title left, then champion banner, then picker on the right, and wraps cleanly on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)