### PR TITLE
Bump Django to 5.2.16 and fix admin filter test

### DIFF
--- a/leagues/tests.py
+++ b/leagues/tests.py
@@ -1229,7 +1229,9 @@ class MatchUpAdminDefaultFilterTest(TestCase):
         )
 
         request = RequestFactory().get("/admin/leagues/matchup/?timeframe=past")
-        f = MatchupTimeframeFilter(request, {"timeframe": "past"}, MatchUp, MagicMock())
+        f = MatchupTimeframeFilter(
+            request, {"timeframe": ["past"]}, MatchUp, MagicMock()
+        )
         qs = f.queryset(request, MatchUp.objects.all())
         self.assertIn(past_game, qs)
         self.assertNotIn(future_game, qs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ channels==4.1.0
 charset-normalizer==3.3.2
 click==8.1.7
 dj-database-url==0.5.0
-Django==4.2.30
+Django==5.2.16
 django-autocomplete-light==3.11.0
 django-datetime-widget==0.9.3
 django-debug-toolbar==4.3.0


### PR DESCRIPTION
## What & why
Applies Dependabot PR #174 (Django 4.2.30 → 5.2.16), which was failing CI. Django 5's `SimpleListFilter` now takes the last value from a list when populating `used_parameters` (real admin changelist requests always supply filter params as lists via `request.GET.lists()`, to support repeated query params). The `test_past_filter_excludes_future_games` test instantiated `MatchupTimeframeFilter` directly with a bare string (`{"timeframe": "past"}`) instead of a list, so on Django 5 the value got index-sliced to a single character (`"past"[-1]` → `"t"`), the "past" branch was never matched, and the future game leaked into the "past" queryset. Application code (`leagues/admin.py`) is unaffected — only the test's direct-construction call needed updating to `{"timeframe": ["past"]}`.

## Checklist
- [x] Tests added/updated and the suite passes (829 tests, verified locally against Django 5.2.16)
- [x] Works on mobile (≤600px) and desktop — no UI changes
- [x] Correct terminology: street hockey / ball hockey (never "ice hockey" or "floor hockey"), and players/forwards/defense/goalies (never "skater") — no user-facing copy changed

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnUrwD5ovTRR4VAZaUc36B)_