### PR TITLE
Fix banner logo rendering oversized in production

### DIFF
--- a/static/assets/css/main.css
+++ b/static/assets/css/main.css
@@ -1450,21 +1450,6 @@
 					margin: 0 0 1em 0;
 				}
 
-				/*
-				 * The logo column is stretched to match the text column's
-				 * height so an admin-uploaded logo of any resolution or
-				 * aspect ratio scales to fit without JS measuring layout.
-				 */
-				#banner .row {
-					display: flex;
-					align-items: stretch;
-				}
-
-				#banner .row:before,
-				#banner .row:after {
-					display: none;
-				}
-
 				#banner .banner-logo-container {
 					flex: 0 0 auto;
 					display: flex;
@@ -1472,10 +1457,18 @@
 					align-items: center;
 				}
 
+				/*
+				 * Fixed cap, not a match to the text column's height: text
+				 * length varies (short vs. long announcements), so tying
+				 * the logo's size to it would make the logo balloon or
+				 * shrink with unrelated copy. A steady cap keeps a
+				 * consistent logo size and scales any upload's resolution
+				 * or aspect ratio to fit without JS.
+				 */
 				#banner .banner-logo {
 					display: block;
 					max-width: 100%;
-					max-height: 100%;
+					max-height: 260px;
 					width: auto;
 					height: auto;
 				}
@@ -1733,17 +1726,12 @@
 					margin: 0 0 1em 0;
 				}
 
-				/* Columns stack, so there's no text-column height to stretch to. */
-				#banner .row {
-					flex-direction: column;
-				}
-
 				#banner .banner-logo-container {
 					margin-top: 20px;
 				}
 
 				#banner .banner-logo {
-					max-height: 240px;
+					max-height: 200px;
 				}
 
 		/* Features */


### PR DESCRIPTION
## What & why

Follow-up to #176. In production the banner logo rendered far larger than the text/button block beside it — the opposite of the intended effect.

Root cause: the previous fix made `#banner .row` a flex container with `align-items: stretch`, intending the logo's column to match the text column's height. But flex `stretch` sizing works backwards from that: the row's auto height is the **max of each item's own natural size**, and the logo's natural size is bound only by its column's *width* (not the text column's height). A real logo wide/tall enough made the whole row balloon to match the image, instead of the image shrinking to match the text. It also unintentionally coupled the logo's size to the announcement text's length — a short announcement would shrink the logo, a long one would let it grow past a normal size.

## Fix

Dropped the row-stretch trick entirely. The logo now gets a simple, fixed `max-height` cap (260px desktop, 200px mobile), independent of the text column, plus `max-width: 100%` so narrow columns/viewports still constrain it. `#banner .row` is back to its original, untouched float-based layout — no more flex override needed.

## Verification

Reproduced the production bug locally with the same large test logo, confirmed the fix caps it correctly at both desktop (1400px) and mobile (375px) widths, and re-confirmed it still works with JavaScript disabled. Full test suite (829 tests) passes.

## Checklist
- [x] Tests added/updated and the suite passes — no new tests needed (CSS only); full suite passes locally
- [x] Works on mobile (≤600px) and desktop — verified via Playwright screenshots at 375px and 1400px
- [x] Correct terminology: street hockey / ball hockey — no user-facing copy changed


---
_Generated by [Claude Code](https://claude.ai/code/session_019rX4QsWfTbhL4DAXi9E1Sb)_