### PR TITLE
Fix dead link on backup goalie summary stat

### DIFF
--- a/leagues/admin.py
+++ b/leagues/admin.py
@@ -16,7 +16,7 @@ from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
 
 from dal import autocomplete
-from .filters import SignupSeasonFilter, _default_signup_season_id
+from .filters import SignupSeasonFilter, BackupGoalieFilter, _default_signup_season_id
 from .forms import MatchUpForm, TeamStatForm
 from .fields import TwelveHourTimeField
 from .widgets import Time12HourWidget
@@ -2148,6 +2148,7 @@ class SeasonSignupAdmin(admin.ModelAdmin):
     list_filter = (
         SignupSeasonFilter,
         "primary_position",
+        BackupGoalieFilter,
         "captain_interest",
         "is_returning",
         "tshirt_size",
@@ -2348,6 +2349,7 @@ class SeasonSignupAdmin(admin.ModelAdmin):
                 primary_position__exact=SeasonSignup.POSITION_GOALIE
             ),
             "backup_goalie_count": backup_goalie_count,
+            "backup_goalie_url": _filtered_url(backup_goalie="yes"),
         }
         return super().changelist_view(request, extra_context=extra_context)
 

--- a/leagues/filters.py
+++ b/leagues/filters.py
@@ -1,5 +1,5 @@
 from django.contrib.admin import SimpleListFilter
-from leagues.models import DraftSession, Week, Season
+from leagues.models import DraftSession, Week, Season, SeasonSignup
 
 
 def _default_signup_season_id():
@@ -75,6 +75,28 @@ class SignupSeasonFilter(SimpleListFilter):
                 "query_string": changelist.get_query_string({self.parameter_name: pk}),
                 "display": title,
             }
+
+
+class BackupGoalieFilter(SimpleListFilter):
+    """
+    Signups who could fill in as a backup goalie: secondary position is
+    Goalie, but primary position isn't (those already show up under the
+    primary "signed up as goalie" count, so they're excluded here to
+    avoid double-counting the same person in both groups).
+    """
+
+    title = "backup goalie"
+    parameter_name = "backup_goalie"
+
+    def lookups(self, request, model_admin):
+        return (("yes", "Can fill in as backup"),)
+
+    def queryset(self, request, queryset):
+        if self.value() == "yes":
+            return queryset.filter(
+                secondary_position=SeasonSignup.POSITION_GOALIE
+            ).exclude(primary_position=SeasonSignup.POSITION_GOALIE)
+        return queryset
 
 
 class RecentSeasonsFilter(SimpleListFilter):

--- a/leagues/test_draft.py
+++ b/leagues/test_draft.py
@@ -4088,6 +4088,39 @@ class SeasonSignupAdminSummaryPanelTests(DraftTestBase):
         url = resp.context["signup_summary"]["primary_goalie_url"]
         self.assertIn(f"primary_position__exact={SeasonSignup.POSITION_GOALIE}", url)
 
+    def test_backup_goalie_tile_links_to_backup_goalie_filter(self):
+        resp = self.client.get(self.changelist_url)
+        url = resp.context["signup_summary"]["backup_goalie_url"]
+        self.assertIn("backup_goalie=yes", url)
+
+    def test_backup_goalie_link_filters_to_backup_goalies_only(self):
+        backup = SeasonSignup.objects.create(
+            season=self.season,
+            first_name="Sammy",
+            last_name="Sub",
+            email="sammy@test.com",
+            primary_position=SeasonSignup.POSITION_CENTER,
+            secondary_position=SeasonSignup.POSITION_GOALIE,
+            captain_interest=SeasonSignup.CAPTAIN_NO,
+        )
+        # Primary goalie who also listed goalie as secondary (redundant, but
+        # not blocked by the form) shouldn't be double-counted as a backup.
+        both = SeasonSignup.objects.create(
+            season=self.season,
+            first_name="Gail",
+            last_name="Bothways",
+            email="gail@test.com",
+            primary_position=SeasonSignup.POSITION_GOALIE,
+            secondary_position=SeasonSignup.POSITION_GOALIE,
+            captain_interest=SeasonSignup.CAPTAIN_NO,
+        )
+        resp = self.client.get(self.changelist_url, {"backup_goalie": "yes"})
+        result_ids = {obj.pk for obj in resp.context["cl"].result_list}
+        self.assertEqual(result_ids, {backup.pk})
+        self.assertNotIn(both.pk, result_ids)
+        self.assertNotIn(self.goalie1.pk, result_ids)
+        self.assertNotIn(self.goalie2.pk, result_ids)
+
 
 # ---------------------------------------------------------------------------
 # Admin: withdrawing / removing a season signup

--- a/templates/admin/leagues/seasonsignup/change_list.html
+++ b/templates/admin/leagues/seasonsignup/change_list.html
@@ -99,10 +99,10 @@
       <span>{% trans "Signed up as goalie" %}</span>
       <span class="count">{{ signup_summary.primary_goalie_count }}</span>
     </a>
-    <div class="signup-summary-row">
+    <a class="signup-summary-row" href="{{ signup_summary.backup_goalie_url }}">
       <span>{% trans "Can fill in as backup" %}</span>
       <span class="count">{{ signup_summary.backup_goalie_count }}</span>
-    </div>
+    </a>
   </div>
 </div>
 {% endif %}


### PR DESCRIPTION
## What & why
The "Can fill in as backup" goalie stat in the Season Signups admin summary panel was styled and hover-highlighted like the other three clickable stats (Total signups, Captain interest, Signed up as goalie), but wasn't actually a link — clicking it did nothing.

Backup goalie status is a two-condition check (secondary position is Goalie, but primary position isn't — otherwise a primary goalie would be double-counted), which doesn't map to a single Django admin field filter. Added a `BackupGoalieFilter` (`leagues/filters.py`) that applies that exact condition, and pointed the tile at it, same as the other three stats.

## Checklist
- [x] Tests added/updated and the suite passes (918 tests)
- [x] Works on mobile (≤600px) and desktop (no layout changes — reuses existing summary panel styling)
- [x] Correct terminology: street hockey / ball hockey, players/goalies (never "skater")


---
_Generated by [Claude Code](https://claude.ai/code/session_01E4sHtn2aJ3oZsVPQoBFDzL)_