### PR TITLE
Add one-click email copying and captain-confirmation visibility

### DIFF
--- a/leagues/admin.py
+++ b/leagues/admin.py
@@ -5,7 +5,7 @@ from django import forms
 from django.contrib import admin, messages
 from django.contrib.admin import SimpleListFilter
 from django.db import models
-from django.db.models import Q, Max, Prefetch, Sum
+from django.db.models import Q, Max, Prefetch, Sum, Exists, OuterRef
 from django.utils.http import urlencode
 from django.utils.html import format_html
 from django.utils import timezone
@@ -2141,6 +2141,7 @@ class SeasonSignupAdmin(admin.ModelAdmin):
         "primary_position",
         "secondary_position",
         "captain_interest_short",
+        "confirmed_captain",
         "is_returning",
         "linked_player",
         "submitted_at",
@@ -2205,7 +2206,44 @@ class SeasonSignupAdmin(admin.ModelAdmin):
 
     captain_interest_short.short_description = "Captain?"
 
-    actions = ["export_roster_csv"]
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.annotate(
+            is_confirmed_captain=Exists(
+                DraftTeam.objects.filter(captain_id=OuterRef("pk"))
+            )
+        )
+
+    def confirmed_captain(self, obj):
+        if obj.is_confirmed_captain:
+            return format_html('<span style="color:#6ee7b7;">✓ Confirmed</span>')
+        return "—"
+
+    confirmed_captain.short_description = "Confirmed captain?"
+    confirmed_captain.admin_order_field = "is_confirmed_captain"
+
+    actions = ["export_roster_csv", "copy_emails"]
+
+    @admin.action(description="Copy email addresses")
+    def copy_emails(self, request, queryset):
+        from django.template.response import TemplateResponse
+
+        emails = list(
+            queryset.exclude(email="")
+            .order_by("last_name", "first_name")
+            .values_list("email", flat=True)
+        )
+        context = {
+            **self.admin_site.each_context(request),
+            "title": "Copy Email Addresses",
+            "emails": emails,
+            "emails_joined": ", ".join(emails),
+            "count": len(emails),
+            "changelist_url": reverse("admin:leagues_seasonsignup_changelist"),
+        }
+        return TemplateResponse(
+            request, "admin/leagues/seasonsignup/copy_emails.html", context
+        )
 
     @admin.action(description="Export selected to CSV (names & positions)")
     def export_roster_csv(self, request, queryset):
@@ -2687,6 +2725,12 @@ class DraftSessionAdmin(admin.ModelAdmin):
             }
             for s in signups
         ]
+        pending_emails = ", ".join(
+            s.email for s in signups if s.pk not in existing_captain_ids if s.email
+        )
+        confirmed_emails = ", ".join(
+            s.email for s in signups if s.pk in existing_captain_ids if s.email
+        )
 
         context = {
             **self.admin_site.each_context(request),
@@ -2695,6 +2739,8 @@ class DraftSessionAdmin(admin.ModelAdmin):
             "candidates": candidates,
             "existing_count": len(existing_captain_ids),
             "total_signups": session.season.signups.count(),
+            "pending_emails": pending_emails,
+            "confirmed_emails": confirmed_emails,
         }
         return TemplateResponse(request, "admin/leagues/setup_teams.html", context)
 

--- a/leagues/templates/admin/leagues/setup_teams.html
+++ b/leagues/templates/admin/leagues/setup_teams.html
@@ -1,7 +1,25 @@
 {% extends "admin/base_site.html" %}
-{% load i18n %}
+{% load i18n static %}
 
 {% block content_title %}<h1>{{ title }}</h1>{% endblock %}
+
+{% block extrahead %}{{ block.super }}
+<script src="{% static 'admin/js/copy_emails.js' %}"></script>
+<style>
+  .copy-emails-btn {
+    background: #4b5563;
+    color: #e5e7eb;
+    border: none;
+    border-radius: 4px;
+    padding: 8px 14px;
+    font-size: 13px;
+    cursor: pointer;
+    min-height: 44px;
+  }
+  .copy-emails-btn:hover { background: #5b6472; }
+  .copy-emails-btn:disabled { opacity: 0.5; cursor: default; }
+</style>
+{% endblock %}
 
 {% block content %}
 <div id="content-main">
@@ -17,6 +35,19 @@
       &middot; {{ existing_count }} team{{ existing_count|pluralize }} already set up
     {% endif %}
   </p>
+
+  {% if candidates %}
+  <div style="display:flex;flex-wrap:wrap;gap:10px;margin-bottom:18px;max-width:640px;">
+    <button type="button" class="copy-emails-btn js-copy-emails"
+            data-emails="{{ pending_emails }}" {% if not pending_emails %}disabled{% endif %}>
+      Copy emails — still deciding
+    </button>
+    <button type="button" class="copy-emails-btn js-copy-emails"
+            data-emails="{{ confirmed_emails }}" {% if not confirmed_emails %}disabled{% endif %}>
+      Copy emails — confirmed captains
+    </button>
+  </div>
+  {% endif %}
 
   {% if candidates %}
   <form method="post">

--- a/leagues/test_draft.py
+++ b/leagues/test_draft.py
@@ -3718,6 +3718,29 @@ class SetupTeamsFromCaptainsTests(DraftTestBase):
         resp = self.client.get(change_url)
         self.assertNotContains(resp, "Set Up Teams from Captains")
 
+    def test_pending_emails_excludes_already_confirmed(self):
+        self.client.post(self.url, {"captains": [self.cap1.pk]})
+        resp = self.client.get(self.url)
+        self.assertIn(self.cap2.email, resp.context["pending_emails"])
+        self.assertIn(self.cap3.email, resp.context["pending_emails"])
+        self.assertNotIn(self.cap1.email, resp.context["pending_emails"])
+
+    def test_confirmed_emails_only_includes_already_confirmed(self):
+        self.client.post(self.url, {"captains": [self.cap1.pk]})
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.context["confirmed_emails"], self.cap1.email)
+
+    def test_before_any_confirmed_pending_has_all_candidates(self):
+        resp = self.client.get(self.url)
+        for cap in (self.cap1, self.cap2, self.cap3):
+            self.assertIn(cap.email, resp.context["pending_emails"])
+        self.assertEqual(resp.context["confirmed_emails"], "")
+
+    def test_copy_email_buttons_rendered_with_data_emails(self):
+        resp = self.client.get(self.url)
+        self.assertContains(resp, "js-copy-emails")
+        self.assertContains(resp, self.cap1.email)
+
 
 # ---------------------------------------------------------------------------
 # Admin: signup CSV export
@@ -3809,6 +3832,79 @@ class SignupCsvExportTests(DraftTestBase):
             if line.startswith(last_name + ","):
                 return line
         self.fail(f"No CSV row found for {last_name}")
+
+
+# ---------------------------------------------------------------------------
+# Admin: copy email addresses / confirmed captain visibility
+# ---------------------------------------------------------------------------
+
+
+class SeasonSignupAdminCopyEmailsTests(DraftTestBase):
+    def setUp(self):
+        super().setUp()
+        from django.contrib.auth.models import User
+
+        admin_user = User.objects.create_superuser("admin", "admin@test.com", "pw")
+        self.client.force_login(admin_user)
+        self.url = reverse("admin:leagues_seasonsignup_changelist")
+
+    def _copy(self, queryset):
+        return self.client.post(
+            self.url,
+            {
+                "action": "copy_emails",
+                "_selected_action": [str(s.pk) for s in queryset],
+            },
+        )
+
+    def test_copy_emails_lists_selected_addresses(self):
+        resp = self._copy([self.cap1, self.cap2])
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, self.cap1.email)
+        self.assertContains(resp, self.cap2.email)
+        self.assertNotContains(resp, self.players[0].email)
+
+    def test_copy_emails_button_carries_data_emails_attribute(self):
+        resp = self._copy([self.cap1])
+        self.assertContains(resp, "js-copy-emails")
+        self.assertContains(resp, f'data-emails="{self.cap1.email}"')
+
+    def test_copy_emails_excludes_blank_addresses(self):
+        self.cap1.email = ""
+        self.cap1.save(update_fields=["email"])
+        resp = self._copy([self.cap1, self.cap2])
+        self.assertEqual(resp.context["count"], 1)
+        self.assertEqual(resp.context["emails"], [self.cap2.email])
+
+    def test_copy_emails_empty_selection_shows_no_emails_message(self):
+        self.cap1.email = ""
+        self.cap1.save(update_fields=["email"])
+        resp = self._copy([self.cap1])
+        self.assertContains(resp, "None of the selected signups have an email")
+
+
+class SeasonSignupAdminConfirmedCaptainColumnTests(DraftTestBase):
+    def setUp(self):
+        super().setUp()
+        from django.contrib.auth.models import User
+
+        admin_user = User.objects.create_superuser("admin", "admin@test.com", "pw")
+        self.client.force_login(admin_user)
+        self.url = reverse("admin:leagues_seasonsignup_changelist")
+
+    def test_captain_with_draft_team_shown_as_confirmed(self):
+        resp = self.client.get(self.url)
+        by_pk = {obj.pk: obj for obj in resp.context["cl"].result_list}
+        self.assertTrue(by_pk[self.cap1.pk].is_confirmed_captain)
+
+    def test_non_captain_signup_not_confirmed(self):
+        resp = self.client.get(self.url)
+        by_pk = {obj.pk: obj for obj in resp.context["cl"].result_list}
+        self.assertFalse(by_pk[self.players[0].pk].is_confirmed_captain)
+
+    def test_confirmed_column_renders_checkmark_for_captain(self):
+        resp = self.client.get(self.url)
+        self.assertContains(resp, "Confirmed")
 
 
 # ---------------------------------------------------------------------------

--- a/static/admin/js/copy_emails.js
+++ b/static/admin/js/copy_emails.js
@@ -1,0 +1,61 @@
+(function () {
+    function showFeedback(button, text) {
+        var original = button.getAttribute('data-original-label');
+        if (!original) {
+            original = button.textContent;
+            button.setAttribute('data-original-label', original);
+        }
+        button.textContent = text;
+        window.setTimeout(function () {
+            button.textContent = original;
+        }, 1800);
+    }
+
+    function fallbackCopy(text) {
+        var textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+        var copied = false;
+        try {
+            copied = document.execCommand('copy');
+        } catch (err) {
+            copied = false;
+        }
+        document.body.removeChild(textarea);
+        return copied;
+    }
+
+    function handleClick(button) {
+        var emails = button.getAttribute('data-emails') || '';
+        if (!emails) {
+            showFeedback(button, 'No emails to copy');
+            return;
+        }
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(emails).then(
+                function () {
+                    showFeedback(button, 'Copied!');
+                },
+                function () {
+                    showFeedback(button, fallbackCopy(emails) ? 'Copied!' : 'Copy failed — select manually');
+                }
+            );
+        } else {
+            showFeedback(button, fallbackCopy(emails) ? 'Copied!' : 'Copy failed — select manually');
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var buttons = document.querySelectorAll('.js-copy-emails');
+        buttons.forEach(function (button) {
+            button.addEventListener('click', function (event) {
+                event.preventDefault();
+                handleClick(button);
+            });
+        });
+    });
+})();

--- a/templates/admin/leagues/seasonsignup/copy_emails.html
+++ b/templates/admin/leagues/seasonsignup/copy_emails.html
@@ -1,0 +1,53 @@
+{% extends "admin/base_site.html" %}
+{% load static %}
+
+{% block content_title %}<h1>{{ title }}</h1>{% endblock %}
+
+{% block extrahead %}{{ block.super }}
+<script src="{% static 'admin/js/copy_emails.js' %}"></script>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+
+  <p style="color:#9ca3af;margin-bottom:18px;font-size:13px;">
+    {{ count }} email address{{ count|pluralize }} selected.
+  </p>
+
+  {% if emails %}
+  <button type="button"
+          class="default js-copy-emails"
+          data-emails="{{ emails_joined }}"
+          style="padding:10px 20px;min-height:44px;margin-bottom:18px;">
+    Copy to Clipboard
+  </button>
+
+  <textarea readonly rows="6" style="
+    display:block;
+    width:100%;
+    max-width:680px;
+    background:#111827;
+    color:#e5e7eb;
+    border:1px solid #374151;
+    border-radius:6px;
+    padding:12px;
+    font-size:13px;
+    font-family:monospace;
+    box-sizing:border-box;
+  ">{{ emails_joined }}</textarea>
+  <p style="color:#9ca3af;font-size:12px;margin-top:8px;max-width:680px;">
+    If the Copy button doesn't work in your browser, click inside the box
+    above, select all (Ctrl/Cmd+A), and copy (Ctrl/Cmd+C).
+  </p>
+  {% else %}
+  <p style="color:#e5e7eb;">None of the selected signups have an email address on file.</p>
+  {% endif %}
+
+  <div style="margin-top:22px;">
+    <a href="{{ changelist_url }}" class="button" style="background:#4b5563;">
+      Back to Season Signups
+    </a>
+  </div>
+
+</div>
+{% endblock %}


### PR DESCRIPTION
## What & why
Wayne needs to contact everyone who didn't outright decline captaining, then lock in whoever agrees.

- **Copying emails, with minimal manual copy/paste:**
  - Two one-click "Copy emails" buttons on the existing "Set Up Teams from Captains" page — one for signups still awaiting a decision, one for already-confirmed captains — using a small shared clipboard-copy JS helper (`static/admin/js/copy_emails.js`).
  - A general "Copy email addresses" bulk action on the Season Signups changelist for any other filtered/selected group, landing on a page with a one-click copy button and a visible textarea fallback for browsers that block clipboard access.
- **Designating a confirmed captain:** no new field needed — checking a candidate's box on "Set Up Teams from Captains" and submitting already creates their `DraftTeam` record, which is the confirmed-captain designation (that page already supports revisiting it incrementally as calls happen). The actual gap was visibility, so a **"Confirmed captain?" column** was added to the Season Signups changelist (single annotated query, no N+1) so it's clear at a glance who's locked in vs. who just expressed interest.

## Checklist
- [x] Tests added/updated and the suite passes (929 tests)
- [x] Works on mobile (≤600px) and desktop (44px+ touch targets on the new buttons, responsive flex layout)
- [x] Correct terminology: street hockey / ball hockey, players/goalies (never "skater")


---
_Generated by [Claude Code](https://claude.ai/code/session_01E4sHtn2aJ3oZsVPQoBFDzL)_