### PR TITLE
Add multi-select captain interest filter to admin

### DIFF
--- a/leagues/admin.py
+++ b/leagues/admin.py
@@ -16,7 +16,12 @@ from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
 
 from dal import autocomplete
-from .filters import SignupSeasonFilter, BackupGoalieFilter, _default_signup_season_id
+from .filters import (
+    SignupSeasonFilter,
+    BackupGoalieFilter,
+    CaptainInterestMultiFilter,
+    _default_signup_season_id,
+)
 from .forms import MatchUpForm, TeamStatForm
 from .fields import TwelveHourTimeField
 from .widgets import Time12HourWidget
@@ -2150,7 +2155,7 @@ class SeasonSignupAdmin(admin.ModelAdmin):
         SignupSeasonFilter,
         "primary_position",
         BackupGoalieFilter,
-        "captain_interest",
+        CaptainInterestMultiFilter,
         "is_returning",
         "tshirt_size",
     )
@@ -2362,7 +2367,7 @@ class SeasonSignupAdmin(admin.ModelAdmin):
             {
                 "label": label,
                 "count": captain_counts.get(value, 0),
-                "url": _filtered_url(captain_interest__exact=value),
+                "url": _filtered_url(captain_interest_ids=str(value)),
             }
             for value, label in SeasonSignup.CAPTAIN_INTEREST_CHOICES
         ]

--- a/leagues/filters.py
+++ b/leagues/filters.py
@@ -99,6 +99,62 @@ class BackupGoalieFilter(SimpleListFilter):
         return queryset
 
 
+class CaptainInterestMultiFilter(SimpleListFilter):
+    """
+    Multi-select captain-interest filter.
+
+    A commissioner reaching out to captain candidates often wants "Yes for
+    sure" and "I can as I'm overdue" together in one view — a plain
+    single-value filter forces two separate page loads to see each, and
+    checkbox selections used for bulk actions (like copying emails) don't
+    survive navigating to a new filtered page. Selecting multiple values
+    here and clicking Apply gets the combined set in one shot instead.
+
+    Reuses the same multi-select widget as the season filter below.
+    """
+
+    title = "captain interest"
+    parameter_name = "captain_interest_ids"
+    template = "admin/season_multiselect_filter.html"
+
+    def __init__(self, request, params, model, model_admin):
+        super().__init__(request, params, model, model_admin)
+        self.request = request
+        self.model_admin = model_admin
+
+    def lookups(self, request, model_admin):
+        return [
+            (str(value), label)
+            for value, label in SeasonSignup.CAPTAIN_INTEREST_CHOICES
+        ]
+
+    def _selected_values(self):
+        if not self.value():
+            return set()
+        return {value for value in self.value().split(",") if value}
+
+    def queryset(self, request, queryset):
+        selected = self._selected_values()
+        if selected:
+            return queryset.filter(captain_interest__in=selected)
+        return queryset
+
+    def choices(self, changelist):
+        selected = self._selected_values()
+        base_query_string = changelist.get_query_string(remove=[self.parameter_name])
+        options = [
+            {"value": value, "display": label, "selected": value in selected}
+            for value, label in self.lookups(self.request, self.model_admin)
+        ]
+        return [
+            {
+                "base_query_string": base_query_string,
+                "options": options,
+                "selected_ids": ",".join(sorted(selected)),
+            }
+        ]
+
+
 class RecentSeasonsFilter(SimpleListFilter):
     title = "season"
     parameter_name = "season"

--- a/leagues/test_draft.py
+++ b/leagues/test_draft.py
@@ -3908,6 +3908,93 @@ class SeasonSignupAdminConfirmedCaptainColumnTests(DraftTestBase):
 
 
 # ---------------------------------------------------------------------------
+# Admin: multi-select captain interest filter
+# ---------------------------------------------------------------------------
+
+
+class CaptainInterestMultiFilterTests(DraftTestBase):
+    """
+    Base fixture: cap1/cap2/cap3 are all CAPTAIN_YES; players[] and the
+    goalies are all CAPTAIN_NO. Tests below flip a couple of signups to
+    OVERDUE / LAST_RESORT so a single filter application can be checked
+    against multiple selected values at once.
+    """
+
+    def setUp(self):
+        super().setUp()
+        from django.contrib.auth.models import User
+
+        admin_user = User.objects.create_superuser("admin", "admin@test.com", "pw")
+        self.client.force_login(admin_user)
+        self.url = reverse("admin:leagues_seasonsignup_changelist")
+
+        self.cap2.captain_interest = SeasonSignup.CAPTAIN_OVERDUE
+        self.cap2.save(update_fields=["captain_interest"])
+        self.cap3.captain_interest = SeasonSignup.CAPTAIN_LAST_RESORT
+        self.cap3.save(update_fields=["captain_interest"])
+
+    def test_single_value_still_works(self):
+        resp = self.client.get(
+            self.url, {"captain_interest_ids": str(SeasonSignup.CAPTAIN_YES)}
+        )
+        result_ids = {obj.pk for obj in resp.context["cl"].result_list}
+        self.assertEqual(result_ids, {self.cap1.pk})
+
+    def test_two_values_combined_in_one_request(self):
+        # This is the reported scenario: "Yes for sure" + "I can as I'm
+        # overdue" selected together, in a single filtered view.
+        resp = self.client.get(
+            self.url,
+            {
+                "captain_interest_ids": f"{SeasonSignup.CAPTAIN_YES},{SeasonSignup.CAPTAIN_OVERDUE}"
+            },
+        )
+        result_ids = {obj.pk for obj in resp.context["cl"].result_list}
+        self.assertEqual(result_ids, {self.cap1.pk, self.cap2.pk})
+        self.assertNotIn(self.cap3.pk, result_ids)
+
+    def test_no_value_shows_everything(self):
+        resp = self.client.get(self.url)
+        result_ids = {obj.pk for obj in resp.context["cl"].result_list}
+        self.assertIn(self.cap1.pk, result_ids)
+        self.assertIn(self.cap3.pk, result_ids)
+
+    def test_copy_emails_action_on_combined_filter_result(self):
+        # Full end-to-end: filter to Yes + Overdue, select everything shown,
+        # run the copy action — both captains' emails should come back in
+        # one pass, no second filter round-trip needed.
+        resp = self.client.get(
+            self.url,
+            {
+                "captain_interest_ids": f"{SeasonSignup.CAPTAIN_YES},{SeasonSignup.CAPTAIN_OVERDUE}"
+            },
+        )
+        shown = list(resp.context["cl"].result_list)
+        copy_resp = self.client.post(
+            self.url,
+            {
+                "action": "copy_emails",
+                "_selected_action": [str(obj.pk) for obj in shown],
+            },
+        )
+        self.assertContains(copy_resp, self.cap1.email)
+        self.assertContains(copy_resp, self.cap2.email)
+        self.assertNotContains(copy_resp, self.cap3.email)
+
+    def test_summary_panel_captain_breakdown_link_filters_correctly(self):
+        resp = self.client.get(self.url)
+        overdue_url = next(
+            row["url"]
+            for row in resp.context["signup_summary"]["captain_breakdown"]
+            if row["label"]
+            == dict(SeasonSignup.CAPTAIN_INTEREST_CHOICES)[SeasonSignup.CAPTAIN_OVERDUE]
+        )
+        followed = self.client.get(overdue_url)
+        result_ids = {obj.pk for obj in followed.context["cl"].result_list}
+        self.assertEqual(result_ids, {self.cap2.pk})
+
+
+# ---------------------------------------------------------------------------
 # Public signup counter
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What & why

Commissioners often need to view captain candidates with multiple interest levels together (e.g., "Yes for sure" + "I can as I'm overdue") to bulk-email them. The existing single-value filter forced separate page loads for each level, and checkbox selections for bulk actions didn't survive navigation.

This change adds a multi-select filter (`CaptainInterestMultiFilter`) that accepts comma-separated captain interest values in a single request, allowing commissioners to combine multiple interest levels and perform bulk actions (like copying emails) without round-tripping through the admin interface.

The filter reuses the existing multi-select widget template and integrates with the signup summary panel's captain breakdown links.

## Checklist
- [x] Tests added/updated and the suite passes
- [x] Works on mobile (≤600px) and desktop
- [x] Correct terminology: street hockey / ball hockey (never "ice hockey" or "floor hockey"), and players/forwards/defense/goalies (never "skater")

https://claude.ai/code/session_01E4sHtn2aJ3oZsVPQoBFDzL