### PR TITLE
Set captain draft rounds after the draw, not before

### DIFF
--- a/.claude/skills/draft-setup/SKILL.md
+++ b/.claude/skills/draft-setup/SKILL.md
@@ -67,8 +67,8 @@ Creates fake signups, players, and a ready-to-draw session. Useful for testing t
 ### 6. Run the draft
 
 1. Commissioner opens `/draft/<session_pk>/commissioner/<token>/`
-2. While still in **SETUP**: set every captain's draft round (the round each captain is auto-drafted onto their own team) — this is now required before positions can be drawn, so the order isn't randomized until every captain's round is locked in
-3. Click **Draw Positions Now** → advances to **DRAW** phase, captain rounds are still editable here if a correction is needed
+2. Click **Draw Positions Now** → advances to **DRAW** phase and randomizes each captain's draft position
+3. Now that draft position is known: set every captain's draft round (the round each captain is auto-drafted onto their own team) — required before advancing to ACTIVE, since it affects which round makes sense for a captain given where they landed in the draw
 4. Advance to **ACTIVE** → live draft begins
 5. Captains pick on their boards; commissioner can `undo` last pick or `swap` two picks
 6. Auto-captain: if a captain's turn is skipped (they don't pick in time), the system can auto-draft them in — controlled in admin

--- a/leagues/draft_views.py
+++ b/leagues/draft_views.py
@@ -813,20 +813,6 @@ def draw_positions(request, session_pk, token):
     if not teams:
         return JsonResponse({"error": "No teams configured."}, status=400)
 
-    # Captain rounds must be locked in before the order is randomized, so
-    # the reveal can't be followed by decisions that might look like they
-    # were made with the draw order already in mind.
-    missing = [t for t in teams if t.captain_draft_round is None]
-    if missing:
-        names = ", ".join(t.captain.full_name for t in missing)
-        return JsonResponse(
-            {
-                "error": f"Set a draft round for every captain before drawing positions. "
-                f"Missing: {names}."
-            },
-            status=400,
-        )
-
     if session.state == DraftSession.STATE_SETUP:
         session.state = DraftSession.STATE_DRAW
         session.save(update_fields=["state"])

--- a/leagues/templates/leagues/draft_board.html
+++ b/leagues/templates/leagues/draft_board.html
@@ -2504,23 +2504,14 @@ function updateCommissionerButtons() {
   const s = state.state;
   let html = '';
   if (s === 'setup') {
-    html = `
-      <div id="captain-rounds-panel" style="display:flex;flex-direction:column;gap:6px;width:100%;">
-        <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;">
-          <span style="font-weight:600;color:#eee;">Set Captain Draft Rounds</span>
-          <span style="font-size:0.78rem;color:#aaa;">Enter the round each captain is auto-drafted onto their team (leave blank to skip) — required for every captain before positions can be drawn.</span>
-          <button class="btn btn-primary" onclick="saveCaptainRounds()" style="padding:4px 14px;">Save Rounds</button>
-          <button class="btn btn-draw" onclick="triggerDraw()" style="padding:4px 14px;">Draw Positions Now</button>
-        </div>
-        ${_advisoryHtml()}
-        ${_captainRoundsTableHtml(false)}
-      </div>`;
+    html = `<button class="btn btn-draw" onclick="triggerDraw()">Draw Positions Now</button>`;
+    html += _advisoryHtml();
   } else if (s === 'draw') {
     html = `
       <div id="captain-rounds-panel" style="display:flex;flex-direction:column;gap:6px;width:100%;">
         <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;">
-          <span style="font-weight:600;color:#eee;">Captain Draft Rounds</span>
-          <span style="font-size:0.78rem;color:#aaa;">Positions are drawn — double-check rounds below, then start the draft.</span>
+          <span style="font-weight:600;color:#eee;">Set Captain Draft Rounds</span>
+          <span style="font-size:0.78rem;color:#aaa;">Positions are drawn — enter the round each captain is auto-drafted onto their team (leave blank to skip), then start the draft.</span>
           <button class="btn btn-primary" onclick="saveCaptainRounds()" style="padding:4px 14px;">Save Rounds</button>
           <button class="btn btn-success" onclick="advanceState()" style="padding:4px 14px;">Start Draft</button>
           ${_lateSignupBtn(['draw'])}
@@ -2847,13 +2838,10 @@ function closeDraw() {
   drawMode = 'draw';
   document.getElementById('draw-overlay-title').textContent = 'Draft Position Draw';
   document.getElementById('draw-done-btn').textContent = 'Start Draft';
-  if (wasDrawMode && IS_COMMISSIONER) {
-    // Captain rounds are now required before positions can even be drawn,
-    // so there's nothing left to confirm here — go straight to Active
-    // instead of making the commissioner click Start Draft separately.
-    updateCommissionerButtons();
-    advanceState();
-  }
+  // Do not auto-advance — commissioner sets captain rounds first, now that
+  // draft position (which round makes sense for each captain) is known,
+  // then clicks Start Draft.
+  if (wasDrawMode && IS_COMMISSIONER) updateCommissionerButtons();
 }
 
 function showRoundRevealOverlay(data) {

--- a/leagues/test_draft.py
+++ b/leagues/test_draft.py
@@ -604,13 +604,11 @@ class BoardViewTests(DraftTestBase):
 class DrawPositionsViewTests(DraftTestBase):
     def setUp(self):
         super().setUp()
-        # Reset positions so draw tests start clean
+        # Reset positions so draw tests start clean. Captain rounds are
+        # deliberately left unset here — which round makes sense for a
+        # captain depends on the draft position they draw, so rounds aren't
+        # required until DRAW -> ACTIVE (see AdvanceStateViewTests).
         self.session.teams.update(draft_position=None)
-        # Captain rounds must be set before positions can be drawn; give
-        # every team one so the happy-path tests aren't blocked by it.
-        for i, team in enumerate(self.session.teams.all(), start=1):
-            team.captain_draft_round = i
-            team.save(update_fields=["captain_draft_round"])
 
     def _draw_url(self):
         return reverse(
@@ -641,27 +639,28 @@ class DrawPositionsViewTests(DraftTestBase):
         response = self.client.post(self._draw_url())
         self.assertEqual(response.status_code, 400)
 
-    def test_draw_blocked_when_a_captain_round_is_missing(self):
+    def test_draw_succeeds_with_no_captain_rounds_set(self):
+        # Rounds are chosen once draft position is known, so the draw must
+        # not require them up front — only DRAW -> ACTIVE does.
+        self.session.teams.update(captain_draft_round=None)
+
+        response = self.client.post(self._draw_url())
+
+        self.assertEqual(response.status_code, 200)
+        self.session.refresh_from_db()
+        self.assertEqual(self.session.state, DraftSession.STATE_DRAW)
+        positions = list(self.session.teams.values_list("draft_position", flat=True))
+        self.assertFalse(any(p is None for p in positions))
+
+    def test_draw_succeeds_with_some_captain_rounds_set(self):
+        self.team1.captain_draft_round = 1
+        self.team1.save(update_fields=["captain_draft_round"])
         self.team2.captain_draft_round = None
         self.team2.save(update_fields=["captain_draft_round"])
 
         response = self.client.post(self._draw_url())
 
-        self.assertEqual(response.status_code, 400)
-        data = json.loads(response.content)
-        self.assertIn(self.cap2.full_name, data["error"])
-        self.session.refresh_from_db()
-        self.assertEqual(self.session.state, DraftSession.STATE_SETUP)
-        self.assertIsNone(self.session.teams.get(pk=self.team1.pk).draft_position)
-
-    def test_draw_blocked_when_all_captain_rounds_missing(self):
-        self.session.teams.update(captain_draft_round=None)
-
-        response = self.client.post(self._draw_url())
-
-        self.assertEqual(response.status_code, 400)
-        self.session.refresh_from_db()
-        self.assertEqual(self.session.state, DraftSession.STATE_SETUP)
+        self.assertEqual(response.status_code, 200)
 
     def test_draw_wrong_token_returns_404(self):
         import uuid


### PR DESCRIPTION
## What & why
A recent change (PR #185) required every captain's draft round to be set *before* positions could be drawn. That's backwards: which round makes sense for a captain to self-draft in depends on the draft position they land on, so that decision can't correctly be made until positions are known.

- Removed the pre-draw captain-round check from `draw_positions`. The real enforcement point — DRAW → ACTIVE, in `advance_state` — was already correct and is untouched.
- Restored the draft board's DRAW-state "Set Captain Draft Rounds" panel (now showing each captain's known draft position alongside the round input) as the one place rounds get set, with an explicit "Start Draft" click afterward — reverting the SETUP-state rounds panel and the "closing the reveal auto-starts the draft" behavior that came with the misplaced check.
- Updated the draft-setup skill doc and tests to match.

Verified end-to-end in a real browser (Playwright against a seeded local draft): SETUP shows only "Draw Positions Now"; closing the reveal lands on DRAW with positions visible and rounds editable; "Start Draft" is correctly blocked until every round is set; filling them in and clicking "Start Draft" moves to ACTIVE.

## Checklist
- [x] Tests added/updated and the suite passes (974 tests)
- [x] Works on mobile (≤600px) and desktop (no layout changes — text/logic only)
- [x] Correct terminology: street hockey / ball hockey, players/goalies (never "skater")


---
_Generated by [Claude Code](https://claude.ai/code/session_01E4sHtn2aJ3oZsVPQoBFDzL)_