### PR TITLE
Add captain roster details page with drafted players' contact info

### DIFF
--- a/leagues/draft_views.py
+++ b/leagues/draft_views.py
@@ -1780,6 +1780,44 @@ def email_team_data(request, session_pk, token):
 
 
 # ---------------------------------------------------------------------------
+# Captain: full roster signup details (contact info, shirt size, etc.)
+# ---------------------------------------------------------------------------
+
+
+def captain_roster_details(request, session_pk, token):
+    """
+    Full signup details — email, cell phone, t-shirt size, notes — for
+    everyone a captain has drafted. Gated by the same private captain
+    token as the rest of the draft-captain views, with no expiration and
+    no draft-complete gate: captains use this in place of the shared
+    spreadsheet they used to keep by hand, so the link is meant to keep
+    working for the life of the season.
+    """
+    captain_team = get_object_or_404(
+        DraftTeam, session_id=session_pk, captain_token=token
+    )
+    session = captain_team.session
+
+    picks = captain_team.draft_picks.select_related("signup").order_by(
+        "round_number", "pick_number"
+    )
+    roster = [
+        {"signup": pick.signup, "is_captain": pick.signup_id == captain_team.captain_id}
+        for pick in picks
+    ]
+
+    return render(
+        request,
+        "leagues/captain_roster_details.html",
+        {
+            "session": session,
+            "captain_team": captain_team,
+            "roster": roster,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
 # Commissioner: add a late signup after the draw
 # ---------------------------------------------------------------------------
 

--- a/leagues/templates/leagues/captain_roster_details.html
+++ b/leagues/templates/leagues/captain_roster_details.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Roster Details – {{ captain_team.team_name }}</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #1a1a1a;
+      color: #e5e5e5;
+      min-height: 100vh;
+      padding: 32px 16px;
+      font-size: 15px;
+    }
+
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+    }
+
+    header {
+      text-align: center;
+      margin-bottom: 24px;
+    }
+
+    header h1 {
+      font-size: 1.6rem;
+      color: #fff;
+      margin-bottom: 6px;
+    }
+
+    header p {
+      color: #9ca3af;
+      font-size: 0.95rem;
+    }
+
+    .instructions {
+      background: #2d2d2d;
+      border: 1px solid #3f3f3f;
+      border-left: 4px solid #8b1a1a;
+      border-radius: 6px;
+      padding: 14px 18px;
+      margin-bottom: 24px;
+      font-size: 0.9rem;
+      color: #d1d5db;
+      line-height: 1.5;
+    }
+
+    .table-scroll {
+      overflow-x: auto;
+      border: 1px solid #3f3f3f;
+      border-radius: 8px;
+    }
+
+    table {
+      width: 100%;
+      min-width: 640px;
+      border-collapse: collapse;
+      background: #2d2d2d;
+    }
+
+    th, td {
+      text-align: left;
+      padding: 12px 14px;
+      font-size: 0.92rem;
+      border-bottom: 1px solid #3f3f3f;
+      vertical-align: top;
+    }
+
+    th {
+      color: #9ca3af;
+      font-weight: 600;
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      background: #242424;
+    }
+
+    tr:last-child td {
+      border-bottom: none;
+    }
+
+    .player-name {
+      color: #fff;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    .captain-badge {
+      display: inline-block;
+      background: #8b1a1a;
+      color: #fff;
+      font-size: 0.65rem;
+      font-weight: 700;
+      padding: 2px 6px;
+      border-radius: 4px;
+      margin-left: 6px;
+      vertical-align: middle;
+    }
+
+    .contact-link {
+      color: #79aec8;
+      text-decoration: none;
+      word-break: break-word;
+    }
+
+    .contact-link:hover {
+      text-decoration: underline;
+    }
+
+    .muted {
+      color: #6b7280;
+    }
+
+    .no-roster {
+      text-align: center;
+      color: #6b7280;
+      padding: 48px 0;
+      font-size: 0.95rem;
+      background: #2d2d2d;
+      border: 1px solid #3f3f3f;
+      border-radius: 8px;
+    }
+
+    .back-link {
+      text-align: center;
+      margin-top: 28px;
+      font-size: 0.85rem;
+    }
+
+    .back-link a {
+      color: #79aec8;
+      text-decoration: none;
+    }
+
+    .back-link a:hover {
+      text-decoration: underline;
+    }
+
+    @media (max-width: 767px) {
+      body { padding: 20px 10px; }
+      header h1 { font-size: 1.3rem; }
+      th, td { padding: 10px; font-size: 0.85rem; }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>{{ captain_team.team_name }}</h1>
+      <p>{{ session.season }} &mdash; Roster Contact Details</p>
+    </header>
+
+    <div class="instructions">
+      Contact info and t-shirt sizes for everyone on your team. This page stays
+      live for the season, so bookmark it instead of copying the info elsewhere.
+    </div>
+
+    {% if roster %}
+    <div class="table-scroll">
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Position</th>
+            <th>Email</th>
+            <th>Cell Phone</th>
+            <th>T-Shirt Size</th>
+            <th>Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for entry in roster %}
+          <tr>
+            <td class="player-name">
+              {{ entry.signup.full_name }}
+              {% if entry.is_captain %}<span class="captain-badge">C</span>{% endif %}
+            </td>
+            <td>{{ entry.signup.get_primary_position_display }}</td>
+            <td>
+              <a class="contact-link" href="mailto:{{ entry.signup.email }}">{{ entry.signup.email }}</a>
+            </td>
+            <td>
+              {% if entry.signup.cell_phone %}
+                <a class="contact-link" href="tel:{{ entry.signup.cell_phone }}">{{ entry.signup.cell_phone }}</a>
+              {% else %}
+                <span class="muted">&mdash;</span>
+              {% endif %}
+            </td>
+            <td>
+              {% if entry.signup.tshirt_size %}
+                {{ entry.signup.get_tshirt_size_display }}
+              {% else %}
+                <span class="muted">&mdash;</span>
+              {% endif %}
+            </td>
+            <td>
+              {% if entry.signup.notes %}
+                {{ entry.signup.notes }}
+              {% else %}
+                <span class="muted">&mdash;</span>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% else %}
+    <div class="no-roster">
+      No players drafted yet &mdash; check back once your team has picks.
+    </div>
+    {% endif %}
+
+    <div class="back-link">
+      <a href="/draft/{{ session.pk }}/captain/{{ captain_team.captain_token }}/">Back to my draft board</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/leagues/templates/leagues/draft_board.html
+++ b/leagues/templates/leagues/draft_board.html
@@ -1372,6 +1372,9 @@
   <button class="btn btn-outline-secondary" onclick="copyTeamEmails()" style="font-size:0.85rem;">
     &#128203; Copy Emails
   </button>
+  <a class="btn btn-outline-secondary" href="/draft/{{ session.pk }}/roster-details/{{ captain_token }}/" style="font-size:0.85rem;text-decoration:none;">
+    &#128203; Roster Details
+  </a>
   <span style="font-size:0.78rem;color:#155724;">Send your roster to all teammates so everyone has each other's contact info.</span>
 </div>
 {% endif %}
@@ -3075,7 +3078,10 @@ function renderTeamPanel() {
       <button class="btn btn-outline-secondary" onclick="copyTeamEmails()" style="flex:1;font-size:0.85rem;padding:7px 12px;">
         &#128203; Copy Emails
       </button>
-    </div>`;
+    </div>
+    <a class="btn btn-outline-secondary" href="/draft/${SESSION_PK}/roster-details/${CAPTAIN_TOKEN}/" style="display:block;text-align:center;font-size:0.85rem;padding:7px 12px;text-decoration:none;margin-top:4px;">
+      &#128203; Roster Details (phone, shirt size, etc.)
+    </a>`;
   }
 
   body.innerHTML = html;

--- a/leagues/test_draft.py
+++ b/leagues/test_draft.py
@@ -2489,6 +2489,79 @@ class EmailTeamDataViewTests(DraftTestBase):
 
 
 # ---------------------------------------------------------------------------
+# captain_roster_details
+# ---------------------------------------------------------------------------
+
+
+class CaptainRosterDetailsViewTests(DraftTestBase):
+    def _url(self, team=None):
+        t = team or self.team1
+        return reverse(
+            "captain_roster_details", args=[self.session.pk, t.captain_token]
+        )
+
+    def test_returns_200_regardless_of_draft_state(self):
+        """Unlike email_team_data, this page has no draft-complete gate —
+        captains should be able to bookmark it for the whole season."""
+        resp = self.client.get(self._url())
+        self.assertEqual(resp.status_code, 200)
+
+        self._activate()
+        resp = self.client.get(self._url())
+        self.assertEqual(resp.status_code, 200)
+
+        self._complete()
+        resp = self.client.get(self._url())
+        self.assertEqual(resp.status_code, 200)
+
+    def test_404_with_wrong_token(self):
+        import uuid
+
+        bad_url = reverse(
+            "captain_roster_details", args=[self.session.pk, uuid.uuid4()]
+        )
+        resp = self.client.get(bad_url)
+        self.assertEqual(resp.status_code, 404)
+
+    def test_shows_empty_state_before_any_picks(self):
+        resp = self.client.get(self._url())
+        self.assertContains(resp, "No players drafted yet")
+
+    def test_roster_contains_contact_details(self):
+        self.players[0].cell_phone = "(202) 555-0143"
+        self.players[0].tshirt_size = "L"
+        self.players[0].notes = "Out the first week of the season"
+        self.players[0].save()
+        self._make_pick(self.team1, self.players[0], 1, 0)
+
+        resp = self.client.get(self._url())
+        self.assertContains(resp, self.players[0].full_name)
+        self.assertContains(resp, self.players[0].email)
+        self.assertContains(resp, "(202) 555-0143")
+        self.assertContains(resp, "Large")
+        self.assertContains(resp, "Out the first week of the season")
+
+    def test_blank_contact_fields_render_placeholder(self):
+        self._make_pick(self.team1, self.players[0], 1, 0)
+        resp = self.client.get(self._url())
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, self.players[0].full_name)
+
+    def test_captain_is_flagged_in_roster(self):
+        self._make_pick(self.team1, self.cap1, 2, 0, auto=True)
+        resp = self.client.get(self._url())
+        self.assertContains(resp, '<span class="captain-badge">C</span>')
+
+    def test_other_team_token_returns_own_roster_only(self):
+        self._make_pick(self.team1, self.players[0], 1, 0)
+        self._make_pick(self.team2, self.players[1], 1, 1)
+
+        resp2 = self.client.get(self._url(team=self.team2))
+        self.assertContains(resp2, self.players[1].full_name)
+        self.assertNotContains(resp2, self.players[0].full_name)
+
+
+# ---------------------------------------------------------------------------
 # draft_results_download
 # ---------------------------------------------------------------------------
 

--- a/leagues/urls.py
+++ b/leagues/urls.py
@@ -23,6 +23,7 @@ from .draft_views import (
     reset_draft,
     set_captain_rounds,
     email_team_data,
+    captain_roster_details,
     draft_results_download,
     draft_sessions_list,
     add_late_signup,
@@ -144,6 +145,11 @@ urlpatterns = [
         "draft/<int:session_pk>/my-team/<uuid:token>/",
         email_team_data,
         name="draft_email_team",
+    ),
+    path(
+        "draft/<int:session_pk>/roster-details/<uuid:token>/",
+        captain_roster_details,
+        name="captain_roster_details",
     ),
     path(
         "draft/<int:session_pk>/add-signup/<uuid:token>/",


### PR DESCRIPTION
## Summary
- Captains have historically organized teammates' contact info (phone, email, shirt size) on a shared spreadsheet after each draft. Adds a page that replaces that: `/draft/<session_pk>/roster-details/<captain_token>/`.
- Reuses the existing `DraftTeam.captain_token` access pattern (unguessable URL, no login) already used for the draft board and "Email My Team" — no new auth mechanism.
- Intentionally permanent: no draft-complete gate and no token expiration, since the intent is a bookmarkable page that stays live for the life of the season/team, same as the spreadsheet it replaces.
- Data comes straight from `SeasonSignup` via `DraftPick.signup` (full name, position, email, cell phone, t-shirt size, notes).
- Linked from the draft board's "DRAFT COMPLETE" bar and the dynamic team-summary panel, next to "Email My Team".

## Test plan
- [x] `python manage.py test` — 984 tests pass
- [x] `python manage.py check` — clean
- [x] `python manage.py makemigrations --check` — no pending model changes (no schema change, view/URL/template only)
- [x] New `CaptainRosterDetailsViewTests` (7 cases): 200 regardless of draft state, 404 on wrong token, empty-state message pre-draft, contact fields render, captain badge shows, one captain's token never exposes another team's roster

🤖 Generated with [Claude Code](https://claude.com/claude-code)